### PR TITLE
Add star history chart to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,25 @@
 
 ---
 
+<p align="center">
+  <a href="https://star-history.com/#Einsia/OpenChronicle&Date">
+    <picture>
+      <source
+        media="(prefers-color-scheme: dark)"
+        srcset="https://api.star-history.com/svg?repos=Einsia/OpenChronicle&type=Date&theme=dark"
+      />
+      <source
+        media="(prefers-color-scheme: light)"
+        srcset="https://api.star-history.com/svg?repos=Einsia/OpenChronicle&type=Date"
+      />
+      <img
+        alt="Star History Chart"
+        src="https://api.star-history.com/svg?repos=Einsia/OpenChronicle&type=Date"
+      />
+    </picture>
+  </a>
+</p>
+
 > **Status:** v0.1.0 · macOS only · early alpha
 
 OpenChronicle gives AI agents a local, inspectable memory built from real screen and app context.


### PR DESCRIPTION
## Summary
- add a Star History chart for `Einsia/OpenChronicle` near the top of the README
- link the chart to Star History so readers can open the interactive view

## Verification
- reviewed the README diff to confirm only the chart block was added