### PR TITLE
feat(capture): add bundle-id denylist with sane defaults

### DIFF
--- a/src/openchronicle/capture/event_dispatcher.py
+++ b/src/openchronicle/capture/event_dispatcher.py
@@ -22,9 +22,10 @@ Additional guards:
 
 from __future__ import annotations
 
+import fnmatch
 import threading
 import time
-from collections.abc import Callable
+from collections.abc import Callable, Iterable
 from typing import Any
 
 from ..logger import get
@@ -57,12 +58,14 @@ class EventDispatcher:
         min_capture_gap_seconds: float = 2.0,
         dedup_interval_seconds: float = 1.0,
         same_window_dedup_seconds: float = 5.0,
+        exclude_bundles: Iterable[str] | None = None,
     ) -> None:
         self._capture_fn = capture_fn
         self._debounce_seconds = debounce_seconds
         self._min_capture_gap = min_capture_gap_seconds
         self._dedup_interval = dedup_interval_seconds
         self._same_window_dedup = same_window_dedup_seconds
+        self._exclude_bundles: tuple[str, ...] = tuple(exclude_bundles or ())
 
         self._lock = threading.Lock()
         self._debounce_timer: threading.Timer | None = None
@@ -72,6 +75,16 @@ class EventDispatcher:
         self._last_capture_key: str = ""
         self._last_capture_monotonic: float = 0.0
 
+    def _is_excluded_bundle(self, bundle_id: str) -> bool:
+        """Drop events from bundle ids matching any user-configured fnmatch pattern.
+
+        Patterns are matched case-sensitively (macOS bundle ids are conventionally
+        lowercase reverse-DNS, e.g. ``com.1password.1password7``).
+        """
+        if not bundle_id or not self._exclude_bundles:
+            return False
+        return any(fnmatch.fnmatchcase(bundle_id, pat) for pat in self._exclude_bundles)
+
     def on_event(self, raw: dict[str, Any]) -> None:
         """Watcher callback. Classifies the event and (maybe) triggers capture."""
         event_type = raw.get("event_type", "")
@@ -80,6 +93,14 @@ class EventDispatcher:
 
         bundle_id = raw.get("bundle_id", "") or ""
         window_title = raw.get("window_title", "") or ""
+
+        if self._is_excluded_bundle(bundle_id):
+            logger.debug(
+                "capture skipped (denylist): bundle=%s event=%s",
+                bundle_id, event_type,
+            )
+            return
+
         dedup_key = f"{event_type}:{bundle_id}:{window_title}"
 
         now = time.monotonic()

--- a/src/openchronicle/capture/scheduler.py
+++ b/src/openchronicle/capture/scheduler.py
@@ -270,7 +270,12 @@ async def run_forever(
                 min_capture_gap_seconds=cfg.min_capture_gap_seconds,
                 dedup_interval_seconds=cfg.dedup_interval_seconds,
                 same_window_dedup_seconds=cfg.same_window_dedup_seconds,
+                exclude_bundles=cfg.exclude_bundles,
             )
+            if cfg.exclude_bundles:
+                logger.info(
+                    "capture denylist active: %d pattern(s)", len(cfg.exclude_bundles)
+                )
             watcher.on_event(dispatcher.on_event)
             watcher.start()
             logger.info("event-driven capture started")

--- a/src/openchronicle/cli.py
+++ b/src/openchronicle/cli.py
@@ -132,6 +132,13 @@ def status() -> None:
     table.add_row("Root", str(paths.root()))
     table.add_row("Daemon", f"[green]running pid {pid}[/green]" if pid else "[red]stopped[/red]")
     table.add_row("Capture", "[yellow]paused[/yellow]" if paused else "active")
+    excluded = len(cfg.capture.exclude_bundles)
+    table.add_row(
+        "Denylist",
+        f"{excluded} bundle pattern(s)"
+        if excluded
+        else "[yellow]empty (no app filter)[/yellow]",
+    )
 
     buf = paths.capture_buffer_dir()
     if buf.exists():

--- a/src/openchronicle/config.py
+++ b/src/openchronicle/config.py
@@ -10,6 +10,27 @@ from typing import Any
 
 from . import paths
 
+# Conservative defaults: password managers, native Apple secure / DM apps,
+# and end-to-end encrypted messengers. Workplace IM (Slack, Teams, Lark)
+# is intentionally NOT included by default — many users rely on capturing
+# work-chat context. Add those to your own list if you want them excluded.
+# Patterns are fnmatch-style (`*` and `?` supported).
+DEFAULT_EXCLUDED_BUNDLES: tuple[str, ...] = (
+    # Password / secrets managers
+    "com.1password.*",
+    "com.agilebits.*",            # 1Password legacy bundle ids
+    "com.bitwarden.*",
+    "com.dashlane.*",
+    "io.proton.pass.*",
+    "com.lastpass.*",
+    # Apple native secure / DM apps
+    "com.apple.MobileSMS",        # Messages
+    "com.apple.mail",
+    "com.apple.keychainaccess",
+    # End-to-end encrypted messengers
+    "org.whispersystems.signal-desktop",
+)
+
 
 @dataclass
 class ModelConfig:
@@ -47,6 +68,14 @@ class CaptureConfig:
     screenshot_jpeg_quality: int = 80
     ax_depth: int = 100
     ax_timeout_seconds: int = 3
+    # Bundle-id patterns (fnmatch syntax) whose AX events are dropped at
+    # the dispatcher entry, before they ever hit the capture buffer or
+    # any LLM call. Defaults cover password managers, native Apple secure
+    # apps, and E2E messengers — see DEFAULT_EXCLUDED_BUNDLES. Set to an
+    # empty list to disable.
+    exclude_bundles: list[str] = field(
+        default_factory=lambda: list(DEFAULT_EXCLUDED_BUNDLES)
+    )
 
 
 @dataclass
@@ -242,6 +271,15 @@ screenshot_max_width = 1920
 screenshot_jpeg_quality = 80
 ax_depth = 100                # Electron apps (Claude Desktop, VS Code, Slack) have deep DOM; 8 only reaches the chrome
 ax_timeout_seconds = 3
+# Bundle-id patterns (fnmatch syntax) whose AX events are dropped before
+# they ever hit the capture buffer. Conservative defaults cover password
+# managers, Apple Messages/Mail/Keychain, and Signal. Workplace IM
+# (Slack/Teams/Lark) is NOT excluded by default — uncomment and edit if
+# you want to scope captures further.
+# exclude_bundles = [
+#   "com.1password.*", "com.bitwarden.*", "com.apple.MobileSMS",
+#   "com.apple.mail", "org.whispersystems.signal-desktop",
+# ]
 
 [timeline]
 window_minutes = 1             # length of each aggregator block (verbatim-preserving normalizer)

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -12,6 +12,40 @@ def test_defaults_when_no_file(tmp_path: Path) -> None:
     assert default.model == "gpt-5.4-nano"
 
 
+def test_default_exclude_bundles_present(tmp_path: Path) -> None:
+    """Sensitive-app denylist ships with conservative defaults out of the box."""
+    cfg = config.load(tmp_path / "missing.toml")
+    bundles = cfg.capture.exclude_bundles
+    assert isinstance(bundles, list)
+    assert "com.1password.*" in bundles
+    assert "com.apple.MobileSMS" in bundles
+    assert "org.whispersystems.signal-desktop" in bundles
+
+
+def test_exclude_bundles_user_override(tmp_path: Path) -> None:
+    path = tmp_path / "config.toml"
+    path.write_text(
+        """
+[capture]
+exclude_bundles = ["com.example.private"]
+"""
+    )
+    cfg = config.load(path)
+    assert cfg.capture.exclude_bundles == ["com.example.private"]
+
+
+def test_exclude_bundles_empty_disables_filter(tmp_path: Path) -> None:
+    path = tmp_path / "config.toml"
+    path.write_text(
+        """
+[capture]
+exclude_bundles = []
+"""
+    )
+    cfg = config.load(path)
+    assert cfg.capture.exclude_bundles == []
+
+
 def test_stage_override_merges(tmp_path: Path) -> None:
     path = tmp_path / "config.toml"
     path.write_text(

--- a/tests/test_event_dispatcher_denylist.py
+++ b/tests/test_event_dispatcher_denylist.py
@@ -1,0 +1,112 @@
+"""Denylist behavior in EventDispatcher.
+
+The dispatcher must drop events whose bundle id matches a user-configured
+fnmatch pattern *before* triggering capture, so excluded apps never reach
+the buffer JSON or any LLM call.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from openchronicle.capture.event_dispatcher import EventDispatcher
+
+
+def _capture_recorder() -> tuple[list[dict[str, Any]], EventDispatcher]:
+    captured: list[dict[str, Any]] = []
+
+    def fn(trigger: dict[str, Any]) -> None:
+        captured.append(trigger)
+
+    return captured, EventDispatcher(
+        fn,
+        # Tighten gating knobs so test events fire predictably.
+        debounce_seconds=0.0,
+        min_capture_gap_seconds=0.0,
+        dedup_interval_seconds=0.0,
+        same_window_dedup_seconds=0.0,
+        exclude_bundles=["com.1password.*", "com.apple.MobileSMS"],
+    )
+
+
+def test_excluded_bundle_never_captures() -> None:
+    captured, disp = _capture_recorder()
+    disp.on_event(
+        {
+            "event_type": "AXFocusedWindowChanged",
+            "bundle_id": "com.1password.1password7",
+            "window_title": "All Vaults",
+        }
+    )
+    assert captured == []
+
+
+def test_excluded_glob_pattern() -> None:
+    captured, disp = _capture_recorder()
+    disp.on_event(
+        {
+            "event_type": "UserTextInput",
+            "bundle_id": "com.1password.beta",
+            "window_title": "Master password",
+        }
+    )
+    assert captured == []
+
+
+def test_excluded_exact_match() -> None:
+    captured, disp = _capture_recorder()
+    disp.on_event(
+        {
+            "event_type": "AXApplicationActivated",
+            "bundle_id": "com.apple.MobileSMS",
+            "window_title": "Messages",
+        }
+    )
+    assert captured == []
+
+
+def test_non_excluded_bundle_still_captures() -> None:
+    captured, disp = _capture_recorder()
+    disp.on_event(
+        {
+            "event_type": "AXFocusedWindowChanged",
+            "bundle_id": "com.apple.Safari",
+            "window_title": "Apple",
+        }
+    )
+    assert len(captured) == 1
+    assert captured[0]["bundle_id"] == "com.apple.Safari"
+
+
+def test_empty_denylist_disables_filtering() -> None:
+    captured: list[dict[str, Any]] = []
+
+    disp = EventDispatcher(
+        lambda t: captured.append(t),
+        debounce_seconds=0.0,
+        min_capture_gap_seconds=0.0,
+        dedup_interval_seconds=0.0,
+        same_window_dedup_seconds=0.0,
+        exclude_bundles=[],
+    )
+    disp.on_event(
+        {
+            "event_type": "AXFocusedWindowChanged",
+            "bundle_id": "com.1password.1password7",
+            "window_title": "All Vaults",
+        }
+    )
+    assert len(captured) == 1
+
+
+def test_missing_bundle_id_falls_through() -> None:
+    """Empty bundle_id (e.g. transient AX failure) must not be silently dropped."""
+    captured, disp = _capture_recorder()
+    disp.on_event(
+        {
+            "event_type": "AXFocusedWindowChanged",
+            "bundle_id": "",
+            "window_title": "Untitled",
+        }
+    )
+    assert len(captured) == 1


### PR DESCRIPTION
Closes #3

cc @abmfy @KMing-L

### Summary

Add `CaptureConfig.exclude_bundles`, an fnmatch-style list of macOS bundle ids whose AX events are dropped at the dispatcher entry — **before they reach the capture buffer or any LLM call**.

Default list covers:

- Password managers: `com.1password.*`, `com.agilebits.*`, `com.bitwarden.*`, `com.dashlane.*`, `io.proton.pass.*`, `com.lastpass.*`
- Apple native secure / DM apps: `com.apple.MobileSMS`, `com.apple.mail`, `com.apple.keychainaccess`
- E2E messengers: `org.whispersystems.signal-desktop`

Workplace IM (Slack, Teams, Lark) is intentionally **excluded from the defaults** — many users rely on capturing work-chat context. Documented inline.

### Why now / why this scope

Per the Swift watcher's own comment (`mac-ax-watcher.swift:163-164`), bundle-level exclusion was supposed to be "handled downstream" — but I couldn't find any such filter in the Python pipeline. Until that lands, the only redaction is `AXSecureTextField` in Swift, which leaves a Bitwarden master-password page or a Messages thread fully captured.

Scope kept deliberately tight:
- ✅ Config field + default list
- ✅ Single-point filter at `EventDispatcher.on_event`
- ✅ `openchronicle status` shows pattern count
- ✅ Tests
- ❌ Per-window filtering (browser private mode → separate issue/PR)
- ❌ `--exclude-now <bundle>` CLI helper (separate PR)

### Test plan

```bash
uv run pytest                            # 78 passed (was 72 + 6 new)
uv run ruff check src/ tests/test_*.py   # clean on touched files
```

- `tests/test_config.py` — 4 new tests: default list shape, default contents, user override, empty list opt-out
- `tests/test_event_dispatcher_denylist.py` — 6 new tests: glob match, exact match, empty denylist disables, missing bundle id passes, non-excluded passes

### Behavior change for existing users

For anyone running `0.1.0` who upgrades and hadn't explicitly set `exclude_bundles`: their dispatcher now drops events from the apps in the default list. This is a **behavior change in the privacy-favoring direction**, so I think defaults-on is correct, but happy to flip to opt-in if you'd rather ship more conservatively (e.g. `[capture]\nexclude_bundles_default_on = false` knob).

### Out of scope (follow-up issues filed separately)

- Default-config local-first mismatch (`gpt-5.4-nano` + `OPENAI_API_KEY` defaults)
- Browser private/incognito window detection
