### PR TITLE
fix: harden daemon resource lifecycle and concurrency primitives

### DIFF
--- a/src/openchronicle/capture/event_dispatcher.py
+++ b/src/openchronicle/capture/event_dispatcher.py
@@ -68,9 +68,16 @@ class EventDispatcher:
         self._debounce_timer: threading.Timer | None = None
         self._pending_trigger: dict[str, Any] | None = None
 
-        self._last_event_time: dict[str, float] = {}
-        self._last_capture_key: str = ""
+        # Tuple keys avoid the silent collision a delimited-string key has
+        # whenever bundle_id or window_title contains the delimiter (e.g.
+        # a window titled "App: Untitled" colliding with "App" + ": Untitled").
+        self._last_event_time: dict[tuple[str, str, str], float] = {}
+        self._last_capture_key: tuple[str, str] = ("", "")
         self._last_capture_monotonic: float = 0.0
+
+    # Periodically prune entries that can no longer suppress dedup so the
+    # map can't grow forever as the user visits many distinct windows.
+    _PRUNE_EVERY: int = 256
 
     def on_event(self, raw: dict[str, Any]) -> None:
         """Watcher callback. Classifies the event and (maybe) triggers capture."""
@@ -80,13 +87,15 @@ class EventDispatcher:
 
         bundle_id = raw.get("bundle_id", "") or ""
         window_title = raw.get("window_title", "") or ""
-        dedup_key = f"{event_type}:{bundle_id}:{window_title}"
+        dedup_key = (event_type, bundle_id, window_title)
 
         now = time.monotonic()
         last = self._last_event_time.get(dedup_key, 0.0)
         if now - last < self._dedup_interval:
             return
         self._last_event_time[dedup_key] = now
+        if len(self._last_event_time) >= self._PRUNE_EVERY:
+            self._prune_event_times(now)
 
         trigger = {
             "event_type": event_type,
@@ -99,6 +108,12 @@ class EventDispatcher:
             self._maybe_capture(trigger)
         elif event_type in _DEBOUNCED_EVENTS:
             self._schedule_debounce(trigger)
+
+    def _prune_event_times(self, now: float) -> None:
+        cutoff = now - self._dedup_interval
+        self._last_event_time = {
+            k: t for k, t in self._last_event_time.items() if t >= cutoff
+        }
 
     def _schedule_debounce(self, trigger: dict[str, Any]) -> None:
         with self._lock:
@@ -128,7 +143,7 @@ class EventDispatcher:
     def _maybe_capture(self, trigger: dict[str, Any]) -> None:
         """Apply last-frame dedup + rate limit, then invoke the capture fn."""
         event_type = trigger["event_type"]
-        key = f"{trigger['bundle_id']}:{trigger['window_title']}"
+        key = (trigger["bundle_id"], trigger["window_title"])
         now = time.monotonic()
         is_focus_change = event_type in (
             "AXFocusedWindowChanged",

--- a/src/openchronicle/capture/event_dispatcher.py
+++ b/src/openchronicle/capture/event_dispatcher.py
@@ -150,26 +150,33 @@ class EventDispatcher:
             "AXApplicationActivated",
         )
 
-        if (
-            not is_focus_change
-            and key == self._last_capture_key
-            and (now - self._last_capture_monotonic) < self._same_window_dedup
-        ):
-            logger.debug(
-                "capture skipped (same-window dedup <%.1fs): %s",
-                self._same_window_dedup, trigger["window_title"][:40],
-            )
-            return
+        # Decide-and-commit under the lock: this method is called from both the
+        # watcher reader thread (immediate events) and the debounce Timer
+        # thread, so reading then writing _last_capture_* without serialization
+        # races and lets two near-simultaneous events bypass dedup/rate-limit.
+        # Keep _capture_fn outside the lock so a slow callback can't stall the
+        # other thread.
+        with self._lock:
+            if (
+                not is_focus_change
+                and key == self._last_capture_key
+                and (now - self._last_capture_monotonic) < self._same_window_dedup
+            ):
+                logger.debug(
+                    "capture skipped (same-window dedup <%.1fs): %s",
+                    self._same_window_dedup, trigger["window_title"][:40],
+                )
+                return
 
-        gap = now - self._last_capture_monotonic
-        if gap < self._min_capture_gap and not is_focus_change:
-            logger.debug(
-                "capture skipped (rate limit %.1fs): %s", gap, event_type
-            )
-            return
+            gap = now - self._last_capture_monotonic
+            if gap < self._min_capture_gap and not is_focus_change:
+                logger.debug(
+                    "capture skipped (rate limit %.1fs): %s", gap, event_type
+                )
+                return
 
-        self._last_capture_key = key
-        self._last_capture_monotonic = now
+            self._last_capture_key = key
+            self._last_capture_monotonic = now
 
         try:
             self._capture_fn(trigger)

--- a/src/openchronicle/capture/scheduler.py
+++ b/src/openchronicle/capture/scheduler.py
@@ -6,6 +6,7 @@ import asyncio
 import contextlib
 import hashlib
 import json
+import queue
 import threading
 import time
 from collections.abc import Callable
@@ -173,8 +174,9 @@ def capture_once(
 class _CaptureRunner:
     """Serializes capture_once calls from the watcher thread + heartbeat task.
 
-    Captures happen on a worker thread so the watcher reader thread never
-    blocks on AX / screenshot I/O.
+    Captures execute on a single dedicated worker thread fed by a bounded
+    queue, so the watcher reader thread never blocks on AX / screenshot I/O
+    and a runaway burst of events can never spawn unbounded threads.
 
     Also enforces *consecutive-duplicate dedup*: if the content fingerprint
     (bundle+title+focused value+visible_text+url) matches the previously
@@ -184,6 +186,14 @@ class _CaptureRunner:
     captures. When deduped, the ``pre_capture_hook`` is NOT fired, so the
     session manager's idle timer isn't reset by meaningless repetition.
     """
+
+    # Bounded queue for backpressure. Captures are de-duplicated by the
+    # dispatcher upstream and again by content-fingerprint here, so a
+    # backlog past this size is a sign the worker is stuck or LLM/AX
+    # calls are slow — drop with a warning rather than build an
+    # unbounded thread/memory backlog.
+    _MAX_PENDING = 16
+    _SENTINEL: Any = object()
 
     def __init__(
         self,
@@ -197,6 +207,35 @@ class _CaptureRunner:
         self._pre_capture_hook = pre_capture_hook
         self._lock = threading.Lock()
         self._last_fingerprint: str | None = None
+        self._queue: queue.Queue[Any] = queue.Queue(maxsize=self._MAX_PENDING)
+        self._worker: threading.Thread | None = None
+
+    def start_worker(self) -> None:
+        """Spawn the dedicated worker thread. Idempotent."""
+        if self._worker is not None and self._worker.is_alive():
+            return
+        self._worker = threading.Thread(
+            target=self._worker_loop, name="capture-worker", daemon=True,
+        )
+        self._worker.start()
+
+    def stop_worker(self, *, timeout: float = 5.0) -> None:
+        """Drain the queue and join the worker thread."""
+        if self._worker is None:
+            return
+        with contextlib.suppress(queue.Full):
+            self._queue.put(self._SENTINEL, timeout=1.0)
+        self._worker.join(timeout=timeout)
+        if self._worker.is_alive():
+            logger.warning("capture worker did not exit within %.1fs", timeout)
+        self._worker = None
+
+    def _worker_loop(self) -> None:
+        while True:
+            item = self._queue.get()
+            if item is self._SENTINEL:
+                return
+            self.run(item)
 
     def run(self, trigger: dict[str, Any] | None) -> None:
         # Serialize so two near-simultaneous triggers don't double-capture.
@@ -226,7 +265,15 @@ class _CaptureRunner:
                 logger.error("capture failed: %s", exc, exc_info=True)
 
     def run_threaded(self, trigger: dict[str, Any] | None) -> None:
-        threading.Thread(target=self.run, args=(trigger,), daemon=True).start()
+        """Enqueue a capture for the worker thread; drop with a warning if full."""
+        try:
+            self._queue.put_nowait(trigger)
+        except queue.Full:
+            logger.warning(
+                "capture queue full (%d pending); dropping trigger=%s",
+                self._queue.qsize(),
+                (trigger or {}).get("event_type") if trigger else "heartbeat",
+            )
 
 
 async def run_forever(
@@ -253,6 +300,7 @@ async def run_forever(
         )
 
     runner = _CaptureRunner(cfg, provider, pre_capture_hook=pre_capture_hook)
+    runner.start_worker()
     watcher: AXWatcherProcess | None = None
     dispatcher: EventDispatcher | None = None
 
@@ -303,10 +351,14 @@ async def run_forever(
             # Park until the task is cancelled so the watcher keeps streaming.
             await asyncio.Event().wait()
     finally:
+        # Stop in producer→consumer order so no new work piles up after we've
+        # told the worker to drain: watcher (no new events) → dispatcher
+        # (cancel debounce) → runner worker (drain + join).
         if watcher is not None:
             watcher.stop()
         if dispatcher is not None:
             dispatcher.shutdown()
+        runner.stop_worker()
 
 
 def cleanup_buffer(

--- a/src/openchronicle/capture/watcher.py
+++ b/src/openchronicle/capture/watcher.py
@@ -10,6 +10,7 @@ adapted to OpenChronicle's bundled-resource layout (mirrors ax_capture.py).
 
 from __future__ import annotations
 
+import contextlib
 import json
 import os
 import platform
@@ -102,15 +103,36 @@ class AXWatcherProcess:
         self._reader_thread.start()
         logger.info("AX watcher started: %s", self._watcher_path)
 
-    def stop(self) -> None:
+    def stop(self, *, join_timeout: float = 5.0) -> None:
+        """Stop the subprocess and join the reader thread.
+
+        Closing ``stdout`` is necessary because the reader loop is blocked
+        on a line read; otherwise ``join`` would hang for the full
+        ``join_timeout`` even after the process is dead.
+        """
         self._stop_event.set()
-        if self._process and self._process.poll() is None:
-            self._process.terminate()
+        proc = self._process
+        if proc and proc.poll() is None:
+            proc.terminate()
             try:
-                self._process.wait(timeout=5)
+                proc.wait(timeout=join_timeout)
             except subprocess.TimeoutExpired:
-                self._process.kill()
+                proc.kill()
+                with contextlib.suppress(subprocess.TimeoutExpired):
+                    proc.wait(timeout=1.0)
+        if proc and proc.stdout is not None:
+            with contextlib.suppress(OSError, ValueError):
+                proc.stdout.close()
         self._process = None
+
+        reader = self._reader_thread
+        if reader is not None and reader.is_alive():
+            reader.join(timeout=join_timeout)
+            if reader.is_alive():
+                logger.warning(
+                    "AX watcher reader thread did not exit within %.1fs", join_timeout
+                )
+        self._reader_thread = None
         logger.info("AX watcher stopped")
 
     def _run_loop(self) -> None:

--- a/src/openchronicle/cli.py
+++ b/src/openchronicle/cli.py
@@ -85,10 +85,13 @@ def start(
     os.setsid()
     if os.fork() != 0:
         os._exit(0)
-    # Redirect stdio to /dev/null
+    # Redirect stdio to /dev/null. After dup2 the original fd is no longer
+    # needed; closing it avoids leaking one descriptor per daemon start.
     devnull = os.open(os.devnull, os.O_RDWR)
     for fd in (0, 1, 2):
         os.dup2(devnull, fd)
+    if devnull > 2:
+        os.close(devnull)
     daemon.run(cfg, capture_only=capture_only)
     os._exit(0)
 

--- a/src/openchronicle/session/tick.py
+++ b/src/openchronicle/session/tick.py
@@ -267,6 +267,17 @@ async def run_daily_safety_net(cfg: Config, manager: SessionManager) -> None:
                 # chance to finish before the catch-up pass would re-process it.
                 await asyncio.sleep(2)
                 await asyncio.to_thread(session_reducer.reduce_all_pending, cfg)
+            # Truncate the WAL sidecar after the heavy daily writes settle —
+            # auto-checkpoint resets the WAL pointer but never shrinks the
+            # file, so without this the sidecar drifts unbounded.
+            try:
+                busy, log_pages, ckpt_pages = await asyncio.to_thread(fts.checkpoint)
+                logger.info(
+                    "daily wal_checkpoint(TRUNCATE): busy=%d log=%d checkpointed=%d",
+                    busy, log_pages, ckpt_pages,
+                )
+            except Exception as exc:  # noqa: BLE001
+                logger.warning("daily wal_checkpoint failed: %s", exc)
         except asyncio.CancelledError:
             raise
         except Exception as exc:  # noqa: BLE001

--- a/src/openchronicle/store/fts.py
+++ b/src/openchronicle/store/fts.py
@@ -113,6 +113,11 @@ def connect(db_path: Path | None = None) -> sqlite3.Connection:
     conn.row_factory = sqlite3.Row
     conn.execute("PRAGMA journal_mode=WAL")
     conn.execute("PRAGMA synchronous=NORMAL")
+    # Make the auto-checkpoint pages explicit (this is also the SQLite default).
+    # Auto-checkpoint resets the WAL pointer but never shrinks the file —
+    # the daemon calls ``checkpoint()`` from the daily tick so the
+    # ``.db-wal`` and ``.db-shm`` sidecars don't drift unbounded.
+    conn.execute("PRAGMA wal_autocheckpoint=1000")
     conn.executescript(SCHEMA)
     from ..session import store as session_store
     from ..timeline import store as timeline_store
@@ -128,6 +133,25 @@ def cursor(db_path: Path | None = None) -> Iterator[sqlite3.Connection]:
         yield conn
     finally:
         conn.close()
+
+
+def checkpoint(mode: str = "TRUNCATE") -> tuple[int, int, int]:
+    """Run ``PRAGMA wal_checkpoint(<mode>)`` and return (busy, log, checkpointed).
+
+    ``TRUNCATE`` is the form that actually shrinks the ``.db-wal`` sidecar;
+    ``PASSIVE`` (default in auto-checkpoint) only advances the read pointer
+    without touching the file. Best invoked from a periodic tick when the
+    daemon is otherwise quiet so we don't fight active readers.
+    """
+    valid = ("PASSIVE", "FULL", "RESTART", "TRUNCATE")
+    mode = mode.upper()
+    if mode not in valid:
+        raise ValueError(f"invalid checkpoint mode {mode!r}; expected one of {valid}")
+    with cursor() as conn:
+        row = conn.execute(f"PRAGMA wal_checkpoint({mode})").fetchone()
+        if row is None:
+            return (0, 0, 0)
+        return (int(row[0]), int(row[1]), int(row[2]))
 
 
 # ─── files table ───────────────────────────────────────────────────────────

--- a/src/openchronicle/writer/session_reducer.py
+++ b/src/openchronicle/writer/session_reducer.py
@@ -27,7 +27,7 @@ import json
 import re
 import sqlite3
 import threading
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from datetime import datetime, timedelta
 from typing import Any
 
@@ -63,7 +63,7 @@ class ReduceResult:
     written: bool            # entry landed in event-YYYY-MM-DD.md
     entry_id: str = ""
     path: str = ""
-    sub_tasks: list[str] = None  # type: ignore[assignment]
+    sub_tasks: list[str] = field(default_factory=list)
     summary: str = ""
     # Session window this reduction covered.
     start_time: datetime | None = None
@@ -72,10 +72,6 @@ class ReduceResult:
     # terminal reduction at session end (or the catch-up path). Drives
     # whether the caller should fire the classifier.
     is_final: bool = True
-
-    def __post_init__(self) -> None:
-        if self.sub_tasks is None:
-            self.sub_tasks = []
 
 
 def reduce_session(


### PR DESCRIPTION
## Summary

Six small fixes to keep the daemon stable across long uptime. Each is independently scoped; happy to split if any one is contentious.

* **`capture/scheduler`** — replace ad-hoc `daemon=True` thread per trigger with a single worker thread fed by a `queue.Queue(maxsize=16)`. Bursts past capacity drop with a warning instead of spawning unbounded threads.
* **`capture/watcher`** — `stop()` now joins the reader thread and closes `process.stdout` so the blocking line read returns. Previously the reader could outlive the subprocess.
* **`capture/event_dispatcher`** — dedup keys are tuples `(event_type, bundle_id, window_title)` instead of `"a:b:c"` strings, removing a silent collision when titles contain `:`. `_last_event_time` is pruned past 256 entries so the map can't grow forever.
* **`store/fts`** — explicit `PRAGMA wal_autocheckpoint` plus a new `checkpoint()` helper. `session/tick.run_daily_safety_net` calls it after the daily reduce so the `.db-wal` sidecar is truncated rather than just rewound.
* **`cli`** — close the `/dev/null` fd after the daemon-fork `dup2` loop. One fd per `openchronicle start` was leaking.
* **`writer/session_reducer`** — `ReduceResult.sub_tasks` switches from `list[str] = None` + `__post_init__` to `field(default_factory=list)` so the type hint is honest.

## Test plan

- [x] `uv run pytest` — 69/69 pass
- [x] `uv run ruff check` — clean
- [ ] Manual: run `openchronicle start --foreground`, observe capture worker logs under load (reviewer)
- [ ] Manual: confirm `.db-wal` is truncated after daily safety-net tick (reviewer)