### PR TITLE
feat(cli): add search, version commands and enhance status output

### DIFF
--- a/src/openchronicle/cli.py
+++ b/src/openchronicle/cli.py
@@ -113,7 +113,7 @@ def _health_status(pid: int | None, last_ts: str | None) -> tuple[str, str]:
         return "running (no captures yet)", "yellow"
     try:
         last = datetime.fromisoformat(last_ts)
-        age = (datetime.now() - last).total_seconds()
+        age = (datetime.now(last.tzinfo) - last).total_seconds()
     except (ValueError, TypeError):
         return "running", "green"
     if age < 300:  # 5 minutes
@@ -207,7 +207,7 @@ def status() -> None:
     if last_ts and last_app:
         try:
             last_dt = datetime.fromisoformat(last_ts)
-            age = (datetime.now() - last_dt).total_seconds()
+            age = (datetime.now(last_dt.tzinfo) - last_dt).total_seconds()
             if age < 60:
                 ago = "just now"
             elif age < 3600:
@@ -1075,13 +1075,13 @@ def search(
     with fts.cursor() as conn:
         results = []
         # Search entries
-        for row in fts.search(conn, query, limit=limit):
-            results.append(("entry", row.created, row.text_env or row.text_user))
+        for row in fts.search(conn, query=query, top_k=limit):
+            results.append(("entry", row.timestamp, row.content))
 
         # Search captures
         cap_limit = max(5, limit - len(results) // 2)
-        for row in fts.search_captures(conn, query, limit=cap_limit):
-            results.append(("capture", row.timestamp, row.caption))
+        for row in fts.search_captures(conn, query=query, limit=cap_limit):
+            results.append(("capture", row.timestamp, row.window_title))
 
         results = results[:limit]
 

--- a/src/openchronicle/cli.py
+++ b/src/openchronicle/cli.py
@@ -17,7 +17,7 @@ from rich.table import Table
 
 from . import config as config_mod
 from . import logger as logger_mod
-from . import paths
+from . import __version__, paths
 from .store import entries as entries_mod
 from .store import fts, index_md
 
@@ -54,6 +54,71 @@ def _read_pid() -> int | None:
     except (FileNotFoundError, ValueError):
         return None
     return pid if _is_pid_alive(pid) else None
+
+
+def _daemon_uptime() -> str:
+    """Return a human-readable uptime string for the running daemon.
+
+    Reads the PID file's mtime as a proxy for daemon start time (the
+    daemon overwrites it on each launch). Returns ``"stopped"`` when
+    the daemon is not running.
+    """
+    pid = _read_pid()
+    if not pid:
+        return "stopped"
+    try:
+        mtime = paths.pid_file().stat().st_mtime
+        delta = datetime.now() - datetime.fromtimestamp(mtime)
+        h, r = divmod(int(delta.total_seconds()), 3600)
+        m = r // 60
+        if h > 24:
+            return f"{h // 24}d {h % 24}h"
+        if h:
+            return f"{h}h {m}m"
+        return f"{m}m"
+    except OSError:
+        return "unknown"
+
+
+def _last_capture_info() -> tuple[str | None, str | None]:
+    """Return ``(timestamp, app_name)`` of the most recent capture buffer file.
+
+    Returns ``(None, None)`` when the buffer directory is empty or missing.
+    """
+    buf = paths.capture_buffer_dir()
+    if not buf.exists():
+        return None, None
+    json_files = sorted(p for p in buf.iterdir() if p.suffix == ".json")
+    if not json_files:
+        return None, None
+    try:
+        import json as _json
+        data = _json.loads(json_files[-1].read_text())
+        ts = data.get("timestamp")
+        meta = data.get("window_meta") or {}
+        app = meta.get("app_name")
+        return ts, app
+    except (OSError, _json.JSONDecodeError):
+        return json_files[-1].stem, None
+
+
+def _health_status(pid: int | None, last_ts: str | None) -> tuple[str, str]:
+    """Return ``(label, style)`` for daemon health.
+
+    ``style`` is a Rich-style string suitable for ``console.print``.
+    """
+    if not pid:
+        return "stopped", "red"
+    if not last_ts:
+        return "running (no captures yet)", "yellow"
+    try:
+        last = datetime.fromisoformat(last_ts)
+        age = (datetime.now() - last).total_seconds()
+    except (ValueError, TypeError):
+        return "running", "green"
+    if age < 300:  # 5 minutes
+        return "healthy", "green"
+    return "stale (no captures in >5m)", "yellow"
 
 
 # ─── commands ─────────────────────────────────────────────────────────────
@@ -127,11 +192,35 @@ def status() -> None:
     cfg = _init()
     pid = _read_pid()
     paused = paths.paused_flag().exists()
+    uptime = _daemon_uptime()
+    last_ts, last_app = _last_capture_info()
+    health_label, health_style = _health_status(pid, last_ts)
 
     table = Table(show_header=False, box=None, padding=(0, 2))
+    table.add_row("Version", __version__)
     table.add_row("Root", str(paths.root()))
     table.add_row("Daemon", f"[green]running pid {pid}[/green]" if pid else "[red]stopped[/red]")
+    table.add_row("Uptime", uptime)
+    table.add_row("Health", f"[{health_style}]{health_label}[/{health_style}]")
     table.add_row("Capture", "[yellow]paused[/yellow]" if paused else "active")
+
+    if last_ts and last_app:
+        try:
+            last_dt = datetime.fromisoformat(last_ts)
+            age = (datetime.now() - last_dt).total_seconds()
+            if age < 60:
+                ago = "just now"
+            elif age < 3600:
+                ago = f"{int(age // 60)}m ago"
+            else:
+                ago = f"{int(age // 3600)}h ago"
+            table.add_row("Last Capture", f"{ago} ({last_app})")
+        except (ValueError, TypeError):
+            table.add_row("Last Capture", last_ts)
+    elif last_ts:
+        table.add_row("Last Capture", last_ts)
+    else:
+        table.add_row("Last Capture", "(none)")
 
     buf = paths.capture_buffer_dir()
     if buf.exists():
@@ -973,6 +1062,58 @@ def clean_all(
         f"{f} memory files, {e} index entries, writer_state={s}.[/green]"
     )
 
+
+
+@app.command()
+def search(
+    query: str = typer.Argument(..., help="Search query (FTS5 full-text syntax)."),
+    limit: int = typer.Option(15, "--limit", "-n", help="Max results."),
+    json_output: bool = typer.Option(False, "--json", "-j", help="Output as JSON."),
+) -> None:
+    """Search captured memory content (entries & captures)."""
+    _init()
+    with fts.cursor() as conn:
+        results = []
+        # Search entries
+        for row in fts.search(conn, query, limit=limit):
+            results.append(("entry", row.created, row.text_env or row.text_user))
+
+        # Search captures
+        cap_limit = max(5, limit - len(results) // 2)
+        for row in fts.search_captures(conn, query, limit=cap_limit):
+            results.append(("capture", row.timestamp, row.caption))
+
+        results = results[:limit]
+
+    if json_output:
+        import json as _json
+        data = [
+            {"type": t, "timestamp": ts, "text": txt[:500]}
+            for t, ts, txt in results
+        ]
+        console.print(_json.dumps(data, ensure_ascii=False, indent=2))
+        return
+
+    if not results:
+        console.print(f"[yellow]No results for '{query}'.[/yellow]")
+        return
+
+    console.print(f"[bold]{len(results)}[/bold] result(s) for [bold]'{query}'[/bold]:\n")
+    for t, ts, txt in results:
+        preview = txt[:300].replace("\n", " ")
+        console.print(f"  [[bold]{t}[/bold]] [cyan]{ts}[/cyan]")
+        console.print(f"       {preview}")
+        console.print("")
+
+
+@app.command()
+def version() -> None:
+    """Show OpenChronicle version and platform info."""
+    import platform
+    console.print(f"[bold]OpenChronicle[/bold]  v{__version__}")
+    console.print(f"  Python  {platform.python_version()}")
+    console.print(f"  Platform  {platform.platform()}")
+    console.print(f"  Data dir  {paths.root()}")
 
 if __name__ == "__main__":
     app()

--- a/src/openchronicle/cli.py
+++ b/src/openchronicle/cli.py
@@ -68,7 +68,8 @@ def _daemon_uptime() -> str:
         return "stopped"
     try:
         mtime = paths.pid_file().stat().st_mtime
-        delta = datetime.now() - datetime.fromtimestamp(mtime)
+        now = datetime.now().astimezone()
+        delta = now - datetime.fromtimestamp(mtime).astimezone()
         h, r = divmod(int(delta.total_seconds()), 3600)
         m = r // 60
         if h > 24:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -3,9 +3,15 @@
 from __future__ import annotations
 
 import os
+import sys
 from pathlib import Path
 
 import pytest
+
+# Ensure the source tree is importable (editable install may be slow over network)
+_src = Path(__file__).resolve().parent.parent / "src"
+if str(_src) not in sys.path:
+    sys.path.insert(0, str(_src))
 
 
 @pytest.fixture

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,21 +1,142 @@
-"""Test CLI helper functions (status enrichment, search, version)."""
+"""Test CLI commands and helper functions (status enrichment, search, version).
+
+Every CLI command is tested via Typer's CliRunner to exercise the actual
+code path the user would invoke. Helper functions have their own unit tests
+for edge cases that are hard to trigger through the runner.
+"""
 
 from __future__ import annotations
 
 import json
-from datetime import datetime
+from datetime import datetime, timedelta
 from pathlib import Path
+
+import pytest
+from typer.testing import CliRunner
 
 from openchronicle import __version__
 from openchronicle.cli import (
     _daemon_uptime,
     _health_status,
     _last_capture_info,
+    app,
 )
 from openchronicle.store import fts
 
+runner = CliRunner()
 
-# ─── _daemon_uptime ────────────────────────────────────────────────────────
+# ═══════════════════════════════════════════════════════════════════
+#  CLI command integration tests (caller's perspective)
+# ═══════════════════════════════════════════════════════════════════
+
+# ─── version ──────────────────────────────────────────────────────
+
+
+def test_version_command() -> None:
+    """`version` prints the OpenChronicle version string."""
+    result = runner.invoke(app, ["version"])
+    assert result.exit_code == 0
+    assert f"OpenChronicle  v{__version__}" in result.stdout
+    assert "Python" in result.stdout
+    assert "Platform" in result.stdout
+
+
+# ─── search ───────────────────────────────────────────────────────
+
+
+def _seed_entry(conn) -> None:
+    from openchronicle.store import entries as entries_mod
+
+    entries_mod.create_file(
+        conn, name="tool-vim.md", description="vim editor", tags=["tool"]
+    )
+    entries_mod.append_entry(
+        conn,
+        name="tool-vim.md",
+        content="User uses list comprehensions in Python.",
+        tags=["editor"],
+    )
+
+
+def _seed_capture(conn) -> None:
+    fts.insert_capture(
+        conn,
+        id="c1",
+        timestamp="2026-04-22T14:00:00+08:00",
+        app_name="Cursor",
+        bundle_id="com.test.cursor",
+        window_title="main.py",
+        focused_role="AXTextArea",
+        focused_value="def f()",
+        visible_text="working on authentication flow",
+        url="",
+    )
+
+
+def test_search_finds_entries(ac_root: Path) -> None:
+    """Searching for content that exists in entries returns results."""
+    with fts.cursor() as conn:
+        _seed_entry(conn)
+
+    result = runner.invoke(app, ["search", "list comprehensions"])
+    assert result.exit_code == 0
+    assert "list comprehensions" in result.stdout
+    assert "entry" in result.stdout or "result" in result.stdout.lower()
+
+
+def test_search_finds_captures(ac_root: Path) -> None:
+    """Searching for content that exists in captures returns results."""
+    with fts.cursor() as conn:
+        _seed_capture(conn)
+
+    result = runner.invoke(app, ["search", "authentication"])
+    assert result.exit_code == 0
+    assert "authentication" in result.stdout or "authentic" in result.stdout
+    assert "capture" in result.stdout.lower()
+
+
+def test_search_no_results(ac_root: Path) -> None:
+    """Searching for nonsense shows a "No results" message."""
+    result = runner.invoke(app, ["search", "xyznonexistent12345"])
+    assert result.exit_code == 0
+    assert "No results" in result.stdout
+
+
+def test_search_json_output(ac_root: Path) -> None:
+    """--json outputs valid JSON with type/timestamp/text fields."""
+    # Ensure config already exists so _init() doesn't emit non-JSON to stdout
+    from openchronicle import config as config_mod
+    config_mod.write_default_if_missing()
+
+    with fts.cursor() as conn:
+        _seed_entry(conn)
+        _seed_capture(conn)
+
+    result = runner.invoke(app, ["search", "Python", "--json"])
+    assert result.exit_code == 0
+    data = json.loads(result.stdout)
+    assert isinstance(data, list)
+    for item in data:
+        assert "type" in item
+        assert "timestamp" in item
+        assert "text" in item
+
+
+def test_search_limit(ac_root: Path) -> None:
+    """--limit caps the number of results returned."""
+    with fts.cursor() as conn:
+        _seed_entry(conn)
+
+    result = runner.invoke(app, ["search", "Python", "-n", "1"])
+    assert result.exit_code == 0
+    assert "1 result" in result.stdout or "1" in result.stdout
+
+
+# ═══════════════════════════════════════════════════════════════════
+#  Helper function unit tests (edge cases for pure functions)
+# ═══════════════════════════════════════════════════════════════════
+
+# ─── _daemon_uptime ───────────────────────────────────────────────
 
 
 def test_daemon_uptime_stopped_when_no_pid() -> None:
@@ -23,7 +144,7 @@ def test_daemon_uptime_stopped_when_no_pid() -> None:
     assert _daemon_uptime() == "stopped"
 
 
-# ─── _health_status ────────────────────────────────────────────────────────
+# ─── _health_status ───────────────────────────────────────────────
 
 
 def test_health_stopped() -> None:
@@ -45,15 +166,13 @@ def test_health_healthy() -> None:
 
 
 def test_health_stale() -> None:
-    from datetime import timedelta
-
     old = (datetime.now() - timedelta(minutes=10)).isoformat()
     label, style = _health_status(9999, old)
     assert "stale" in label
     assert style == "yellow"
 
 
-# ─── _last_capture_info ────────────────────────────────────────────────────
+# ─── _last_capture_info ───────────────────────────────────────────
 
 
 def test_last_capture_none_when_dir_missing() -> None:
@@ -86,57 +205,3 @@ def test_last_capture_finds_newest(ac_root: Path) -> None:
     # c2 sorts after c1
     assert ts == "2026-04-22T14:05:00+08:00", f"got ts={ts!r}"
     assert app == "Safari", f"got app={app!r}"
-
-
-# ─── version constant ──────────────────────────────────────────────────────
-
-
-def test_version_is_string() -> None:
-    assert isinstance(__version__, str)
-    assert "." in __version__
-
-
-# ─── search integration (via fts) ──────────────────────────────────────────
-
-
-def _seed_capture(conn, *, id, ts, app, title, value, text, url=""):
-    fts.insert_capture(
-        conn, id=id, timestamp=ts, app_name=app,
-        bundle_id="com.test." + app.lower(),
-        window_title=title, focused_role="AXTextArea",
-        focused_value=value, visible_text=text, url=url,
-    )
-
-
-def test_search_finds_entries(ac_root: Path) -> None:
-    from openchronicle.store import entries as entries_mod
-
-    with fts.cursor() as conn:
-        entries_mod.create_file(
-            conn, name="tool-vim.md", description="vim editor", tags=["tool"]
-        )
-        entries_mod.append_entry(
-            conn, name="tool-vim.md",
-            content="User uses list comprehensions in Python.",
-            tags=["editor"],
-        )
-
-        results = fts.search(conn, query="list comprehensions", top_k=10)
-    assert len(results) >= 1
-
-
-def test_search_finds_captures(ac_root: Path) -> None:
-    with fts.cursor() as conn:
-        _seed_capture(conn, id="c1", ts="2026-04-22T14:00:00+08:00",
-                      app="Cursor", title="main.py", value="def f()",
-                      text="working on authentication flow")
-
-        results = fts.search_captures(conn, query="authentication", limit=10)
-    assert len(results) == 1
-    assert results[0].id == "c1"
-
-
-def test_search_returns_empty_for_nonsense(ac_root: Path) -> None:
-    with fts.cursor() as conn:
-        results = fts.search(conn, query="xyznonexistent12345", top_k=10)
-    assert len(results) == 0

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,0 +1,142 @@
+"""Test CLI helper functions (status enrichment, search, version)."""
+
+from __future__ import annotations
+
+import json
+from datetime import datetime
+from pathlib import Path
+
+from openchronicle import __version__
+from openchronicle.cli import (
+    _daemon_uptime,
+    _health_status,
+    _last_capture_info,
+)
+from openchronicle.store import fts
+
+
+# ─── _daemon_uptime ────────────────────────────────────────────────────────
+
+
+def test_daemon_uptime_stopped_when_no_pid() -> None:
+    """Returns "stopped" when no PID file exists."""
+    assert _daemon_uptime() == "stopped"
+
+
+# ─── _health_status ────────────────────────────────────────────────────────
+
+
+def test_health_stopped() -> None:
+    label, style = _health_status(None, None)
+    assert label == "stopped"
+    assert style == "red"
+
+
+def test_health_running_no_captures() -> None:
+    label, style = _health_status(9999, None)
+    assert "no captures" in label
+    assert style == "yellow"
+
+
+def test_health_healthy() -> None:
+    label, style = _health_status(9999, datetime.now().isoformat())
+    assert label == "healthy"
+    assert style == "green"
+
+
+def test_health_stale() -> None:
+    from datetime import timedelta
+
+    old = (datetime.now() - timedelta(minutes=10)).isoformat()
+    label, style = _health_status(9999, old)
+    assert "stale" in label
+    assert style == "yellow"
+
+
+# ─── _last_capture_info ────────────────────────────────────────────────────
+
+
+def test_last_capture_none_when_dir_missing() -> None:
+    """No capture-buffer dir → returns (None, None)."""
+    ts, app = _last_capture_info()
+    assert ts is None
+    assert app is None
+
+
+def test_last_capture_finds_newest(ac_root: Path) -> None:
+    """Write two capture buffer files; the newest filename-sorted is returned."""
+    from openchronicle import paths as oc_paths
+
+    buf = oc_paths.capture_buffer_dir()
+    buf.mkdir(parents=True, exist_ok=True)
+    (buf / "c1.json").write_text(
+        json.dumps({
+            "timestamp": "2026-04-22T14:00:00+08:00",
+            "window_meta": {"app_name": "Cursor"},
+        })
+    )
+    (buf / "c2.json").write_text(
+        json.dumps({
+            "timestamp": "2026-04-22T14:05:00+08:00",
+            "window_meta": {"app_name": "Safari"},
+        })
+    )
+
+    ts, app = _last_capture_info()
+    # c2 sorts after c1
+    assert ts == "2026-04-22T14:05:00+08:00", f"got ts={ts!r}"
+    assert app == "Safari", f"got app={app!r}"
+
+
+# ─── version constant ──────────────────────────────────────────────────────
+
+
+def test_version_is_string() -> None:
+    assert isinstance(__version__, str)
+    assert "." in __version__
+
+
+# ─── search integration (via fts) ──────────────────────────────────────────
+
+
+def _seed_capture(conn, *, id, ts, app, title, value, text, url=""):
+    fts.insert_capture(
+        conn, id=id, timestamp=ts, app_name=app,
+        bundle_id="com.test." + app.lower(),
+        window_title=title, focused_role="AXTextArea",
+        focused_value=value, visible_text=text, url=url,
+    )
+
+
+def test_search_finds_entries(ac_root: Path) -> None:
+    from openchronicle.store import entries as entries_mod
+
+    with fts.cursor() as conn:
+        entries_mod.create_file(
+            conn, name="tool-vim.md", description="vim editor", tags=["tool"]
+        )
+        entries_mod.append_entry(
+            conn, name="tool-vim.md",
+            content="User uses list comprehensions in Python.",
+            tags=["editor"],
+        )
+
+        results = fts.search(conn, query="list comprehensions", top_k=10)
+    assert len(results) >= 1
+
+
+def test_search_finds_captures(ac_root: Path) -> None:
+    with fts.cursor() as conn:
+        _seed_capture(conn, id="c1", ts="2026-04-22T14:00:00+08:00",
+                      app="Cursor", title="main.py", value="def f()",
+                      text="working on authentication flow")
+
+        results = fts.search_captures(conn, query="authentication", limit=10)
+    assert len(results) == 1
+    assert results[0].id == "c1"
+
+
+def test_search_returns_empty_for_nonsense(ac_root: Path) -> None:
+    with fts.cursor() as conn:
+        results = fts.search(conn, query="xyznonexistent12345", top_k=10)
+    assert len(results) == 0


### PR DESCRIPTION
## Summary

Adds three CLI enhancements to OpenChronicle:

### `openchronicle search <query>`
Full-text search over both entries and captures using the existing FTS5 engine. Supports `--json` flag for machine-readable output.

### `openchronicle version`
Shows the installed OpenChronicle version, Python version, and data directory path.

### `openchronicle status` (enhanced)
Now includes:
- **Version** — the installed version
- **Uptime** — how long the daemon has been running
- **Health** — healthy / stale (no captures in >5m) / stopped
- **Last Capture** — when the last capture happened and from which app

### Helper functions added
- `_daemon_uptime()` — reads PID file mtime for uptime calculation
- `_last_capture_info()` — inspects the capture buffer for most recent snapshot
- `_health_status()` — determines daemon health based on PID + capture recency

### Tests
Added `tests/test_cli.py` with 11 tests covering all new helpers, version constant check, and FTS search integration.

## Related

Closes the CLI enhancement request: search + status + version commands.