### PR TITLE
Probe each stage's LLM from `openchronicle status`

### DIFF
--- a/docs/config.md
+++ b/docs/config.md
@@ -219,4 +219,16 @@ openchronicle stop && openchronicle start
 openchronicle status
 ```
 
-`status` prints the resolved model for each stage, so a typo in `[models.timeline]` is visible immediately.
+`status` prints the resolved model for each stage **and probes each stage's provider** with a tiny round-trip (`max_tokens=4`, ~5s timeout). Each row shows one of:
+
+- `gpt-5.4-nano   ✓ 234 ms` — provider answered.
+- `claude-haiku-4-5   ✗ AuthenticationError: …` — provider rejected the request. Typos in `model`, missing `api_key_env`, wrong `base_url`, or expired keys all show up here on the first `status` call instead of silently failing inside the writer hours later.
+
+Probes for stages that share an identical `(model, base_url, api_key)` are deduplicated, so the common case (one model for all four stages) makes one network call. Run them in parallel and the whole status command stays under ~5s even if one provider is slow.
+
+To skip the network round-trip — e.g. on a flight, in CI, or just to inspect the resolved config — set the mock env var:
+
+```bash
+OPENCHRONICLE_LLM_MOCK=1 openchronicle status
+# rows show: ✓ mocked
+```

--- a/src/openchronicle/cli.py
+++ b/src/openchronicle/cli.py
@@ -187,8 +187,9 @@ def _ping_stages(cfg: config_mod.Config, stages: tuple[str, ...]) -> dict:
     timeout.
     """
     from concurrent.futures import ThreadPoolExecutor
+    from dataclasses import replace
 
-    from .writer.llm import ping_stage
+    from .writer.llm import PingResult, ping_stage
 
     # Dedup by (model, base_url, resolved api key) — common case is one model
     # for all four stages, which should hit the network once.
@@ -210,10 +211,7 @@ def _ping_stages(cfg: config_mod.Config, stages: tuple[str, ...]) -> dict:
             try:
                 res = future.result(timeout=12.0)
             except Exception as exc:  # noqa: BLE001
-                res = None
                 err_label = type(exc).__name__
-                from .writer.llm import PingResult
-
                 for stage in members:
                     m = cfg.model_for(stage)
                     results[stage] = PingResult(
@@ -224,8 +222,6 @@ def _ping_stages(cfg: config_mod.Config, stages: tuple[str, ...]) -> dict:
             for stage in members:
                 # Reuse the same PingResult across stages that share a config,
                 # but tag each with its own stage name so callers can map back.
-                from dataclasses import replace
-
                 results[stage] = replace(res, stage=stage)
     return results
 

--- a/src/openchronicle/cli.py
+++ b/src/openchronicle/cli.py
@@ -169,11 +169,78 @@ def status() -> None:
         tlb_last = tlb_row[1] if tlb_row and tlb_row[1] else "(none)"
         table.add_row("Timeline", f"{tlb_count} blocks, last end: {tlb_last}")
 
-    for stage in ("timeline", "reducer", "classifier", "compact"):
+    stages = ("timeline", "reducer", "classifier", "compact")
+    ping_results = _ping_stages(cfg, stages)
+    for stage in stages:
         m = cfg.model_for(stage)
-        table.add_row(f"Model ({stage})", m.model)
+        ping = _format_ping(ping_results.get(stage))
+        table.add_row(f"Model ({stage})", f"{m.model}   {ping}")
 
     console.print(table)
+
+
+def _ping_stages(cfg: config_mod.Config, stages: tuple[str, ...]) -> dict:
+    """Probe each stage's configured model, deduping identical configs.
+
+    Returns a dict keyed by stage name -> PingResult. Pings run in parallel
+    so a single hung provider can't stretch the wait past the per-call
+    timeout.
+    """
+    from concurrent.futures import ThreadPoolExecutor
+
+    from .writer.llm import ping_stage
+
+    # Dedup by (model, base_url, resolved api key) — common case is one model
+    # for all four stages, which should hit the network once.
+    dedup: dict[tuple[str, str, str], list[str]] = {}
+    for stage in stages:
+        m = cfg.model_for(stage)
+        key = (m.model, m.base_url, config_mod.resolve_api_key(m) or "")
+        dedup.setdefault(key, []).append(stage)
+
+    results: dict = {}
+    if not dedup:
+        return results
+    with ThreadPoolExecutor(max_workers=min(4, len(dedup))) as pool:
+        future_to_stages = {
+            pool.submit(ping_stage, cfg, members[0]): members
+            for members in dedup.values()
+        }
+        for future, members in future_to_stages.items():
+            try:
+                res = future.result(timeout=12.0)
+            except Exception as exc:  # noqa: BLE001
+                res = None
+                err_label = type(exc).__name__
+                from .writer.llm import PingResult
+
+                for stage in members:
+                    m = cfg.model_for(stage)
+                    results[stage] = PingResult(
+                        stage=stage, model=m.model, ok=False,
+                        latency_ms=None, error=err_label,
+                    )
+                continue
+            for stage in members:
+                # Reuse the same PingResult across stages that share a config,
+                # but tag each with its own stage name so callers can map back.
+                from dataclasses import replace
+
+                results[stage] = replace(res, stage=stage)
+    return results
+
+
+def _format_ping(res) -> str:
+    """Render a PingResult as a short Rich-styled cell."""
+    if res is None:
+        return "[dim]?[/dim]"
+    if res.mocked:
+        return "[dim]✓ mocked[/dim]"
+    if res.ok:
+        latency = f"{res.latency_ms} ms" if res.latency_ms is not None else "ok"
+        return f"[green]✓[/green] {latency}"
+    err = res.error or "failed"
+    return f"[red]✗[/red] {err}"
 
 
 @app.command()

--- a/src/openchronicle/writer/llm.py
+++ b/src/openchronicle/writer/llm.py
@@ -4,12 +4,24 @@ from __future__ import annotations
 
 import json
 import os
+import time
+from dataclasses import dataclass
 from typing import Any
 
 from ..config import Config, resolve_api_key
 from ..logger import get
 
 logger = get("openchronicle.writer")
+
+
+@dataclass
+class PingResult:
+    stage: str
+    model: str
+    ok: bool
+    latency_ms: int | None
+    error: str | None
+    mocked: bool = False
 
 
 def call_llm(
@@ -78,6 +90,60 @@ def extract_text(response: Any) -> str:
         return response.choices[0].message.content or ""
     except (AttributeError, IndexError):
         return ""
+
+
+def ping_stage(cfg: Config, stage: str, *, timeout: float = 5.0) -> PingResult:
+    """Send a tiny round-trip request to the stage's configured model.
+
+    Returns a PingResult with success, latency, and a short error label on
+    failure. Honors OPENCHRONICLE_LLM_MOCK=1 by returning a mocked-ok result
+    without touching the network. Never raises — `status` and similar
+    informational callers must remain non-fatal.
+    """
+    model_cfg = cfg.model_for(stage)
+    if os.environ.get("OPENCHRONICLE_LLM_MOCK") == "1":
+        return PingResult(
+            stage=stage, model=model_cfg.model, ok=True,
+            latency_ms=0, error=None, mocked=True,
+        )
+
+    try:
+        import litellm  # lazy import — keeps CLI startup fast
+    except ImportError as exc:
+        return PingResult(
+            stage=stage, model=model_cfg.model, ok=False,
+            latency_ms=None, error=f"ImportError: {exc}",
+        )
+
+    kwargs: dict[str, Any] = {
+        "model": model_cfg.model,
+        "messages": [{"role": "user", "content": "Reply with 'ok'."}],
+        "max_tokens": 4,
+        "timeout": timeout,
+    }
+    if model_cfg.base_url:
+        kwargs["api_base"] = model_cfg.base_url
+    api_key = resolve_api_key(model_cfg)
+    if api_key:
+        kwargs["api_key"] = api_key
+
+    start = time.monotonic()
+    try:
+        litellm.completion(**kwargs)
+    except Exception as exc:  # noqa: BLE001
+        label = type(exc).__name__
+        msg = str(exc).strip().splitlines()[0] if str(exc).strip() else ""
+        if msg:
+            label = f"{label}: {msg[:60]}"
+        return PingResult(
+            stage=stage, model=model_cfg.model, ok=False,
+            latency_ms=None, error=label[:80],
+        )
+    latency_ms = int((time.monotonic() - start) * 1000)
+    return PingResult(
+        stage=stage, model=model_cfg.model, ok=True,
+        latency_ms=latency_ms, error=None,
+    )
 
 
 def extract_tool_calls(response: Any) -> list[dict[str, Any]]:

--- a/tests/test_cli_status.py
+++ b/tests/test_cli_status.py
@@ -1,0 +1,49 @@
+"""Tests for `openchronicle status` — particularly the per-stage LLM probes."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+from typer.testing import CliRunner
+
+from openchronicle import cli
+from openchronicle.writer import llm as llm_mod
+
+
+def test_status_renders_mocked_pings(ac_root: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """OPENCHRONICLE_LLM_MOCK=1 short-circuits each stage probe to '✓ mocked'."""
+    monkeypatch.setenv("OPENCHRONICLE_LLM_MOCK", "1")
+    runner = CliRunner()
+    result = runner.invoke(cli.app, ["status"])
+    assert result.exit_code == 0, result.output
+    out = result.output
+    assert "Model (timeline)" in out
+    assert "Model (reducer)" in out
+    assert "Model (classifier)" in out
+    assert "Model (compact)" in out
+    # All four stages share the default model, so they all show the mocked tick.
+    assert out.count("mocked") >= 4
+
+
+def test_status_renders_probe_failure(ac_root: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """When ping_stage raises, status shows ✗ <ErrorClass> and still exits 0."""
+    # Make sure mock-mode is OFF so the real ping_stage path runs.
+    monkeypatch.delenv("OPENCHRONICLE_LLM_MOCK", raising=False)
+
+    def boom(cfg, stage, *, timeout=5.0):  # noqa: ARG001
+        return llm_mod.PingResult(
+            stage=stage,
+            model=cfg.model_for(stage).model,
+            ok=False,
+            latency_ms=None,
+            error="AuthenticationError",
+        )
+
+    monkeypatch.setattr(llm_mod, "ping_stage", boom)
+
+    runner = CliRunner()
+    result = runner.invoke(cli.app, ["status"])
+    assert result.exit_code == 0, result.output
+    assert "AuthenticationError" in result.output
+    assert "✗" in result.output

--- a/tests/test_cli_status.py
+++ b/tests/test_cli_status.py
@@ -26,6 +26,40 @@ def test_status_renders_mocked_pings(ac_root: Path, monkeypatch: pytest.MonkeyPa
     assert out.count("mocked") >= 4
 
 
+def test_ping_stages_dedups_identical_configs(
+    ac_root: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Stages with identical (model, base_url, api_key) only ping the network once.
+
+    The default config gives every stage the same model, so a four-stage
+    status call should invoke ping_stage exactly once and reuse the result
+    via dataclasses.replace for the other three.
+    """
+    monkeypatch.delenv("OPENCHRONICLE_LLM_MOCK", raising=False)
+    call_count = {"n": 0}
+
+    def counting_ping(cfg, stage, *, timeout=5.0):  # noqa: ARG001
+        call_count["n"] += 1
+        return llm_mod.PingResult(
+            stage=stage,
+            model=cfg.model_for(stage).model,
+            ok=True,
+            latency_ms=42,
+            error=None,
+        )
+
+    monkeypatch.setattr(llm_mod, "ping_stage", counting_ping)
+
+    runner = CliRunner()
+    result = runner.invoke(cli.app, ["status"])
+
+    assert result.exit_code == 0, result.output
+    # All four stages share the default model, so dedup collapses to one network call.
+    assert call_count["n"] == 1, f"expected 1 ping_stage call, got {call_count['n']}"
+    # …but every stage row still shows a tick — the result was replicated, not skipped.
+    assert result.output.count("42 ms") == 4
+
+
 def test_status_renders_probe_failure(ac_root: Path, monkeypatch: pytest.MonkeyPatch) -> None:
     """When ping_stage raises, status shows ✗ <ErrorClass> and still exits 0."""
     # Make sure mock-mode is OFF so the real ping_stage path runs.

--- a/tests/test_writer_llm_ping.py
+++ b/tests/test_writer_llm_ping.py
@@ -1,0 +1,125 @@
+"""Unit tests for ``writer.llm.ping_stage``.
+
+The integration path (status command rendering ✓ / ✗) is covered in
+``test_cli_status.py``. These tests pin down ping_stage's own contract:
+mock-env shortcut, success latency, error label format, and truncation.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from openchronicle.config import Config, ModelConfig
+from openchronicle.writer import llm as llm_mod
+
+
+def _cfg_with_model(model: str = "gpt-5.4-nano", api_key: str = "sk-test") -> Config:
+    return Config(models={"default": ModelConfig(model=model, api_key=api_key)})
+
+
+def test_ping_stage_mock_env_returns_mocked(monkeypatch: pytest.MonkeyPatch) -> None:
+    """OPENCHRONICLE_LLM_MOCK=1 short-circuits before any litellm import."""
+    monkeypatch.setenv("OPENCHRONICLE_LLM_MOCK", "1")
+    cfg = _cfg_with_model()
+
+    res = llm_mod.ping_stage(cfg, "timeline")
+
+    assert res.ok is True
+    assert res.mocked is True
+    assert res.latency_ms == 0
+    assert res.error is None
+    assert res.stage == "timeline"
+    assert res.model == "gpt-5.4-nano"
+
+
+def test_ping_stage_success_records_latency(monkeypatch: pytest.MonkeyPatch) -> None:
+    """A normal litellm.completion return yields ok=True with a non-negative latency."""
+    monkeypatch.delenv("OPENCHRONICLE_LLM_MOCK", raising=False)
+    import litellm
+
+    calls: list[dict] = []
+
+    def fake_completion(**kwargs):
+        calls.append(kwargs)
+        return object()  # ping_stage doesn't read the response
+
+    monkeypatch.setattr(litellm, "completion", fake_completion)
+    cfg = _cfg_with_model()
+
+    res = llm_mod.ping_stage(cfg, "reducer")
+
+    assert res.ok is True
+    assert res.mocked is False
+    assert res.error is None
+    assert res.latency_ms is not None and res.latency_ms >= 0
+    # ping should keep the request small and bounded.
+    assert calls[0]["max_tokens"] == 4
+    assert "timeout" in calls[0]
+
+
+def test_ping_stage_failure_label_includes_class_and_message(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A raised exception becomes 'ClassName: <first-line>' truncated to 80 chars."""
+    monkeypatch.delenv("OPENCHRONICLE_LLM_MOCK", raising=False)
+    import litellm
+
+    class AuthenticationError(Exception):
+        pass
+
+    def boom(**kwargs):
+        raise AuthenticationError("Invalid api key sk-bo***ee")
+
+    monkeypatch.setattr(litellm, "completion", boom)
+    cfg = _cfg_with_model()
+
+    res = llm_mod.ping_stage(cfg, "classifier")
+
+    assert res.ok is False
+    assert res.error is not None
+    assert res.error.startswith("AuthenticationError")
+    assert "Invalid api key" in res.error
+    assert len(res.error) <= 80
+
+
+def test_ping_stage_failure_with_empty_message_falls_back_to_class(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """When str(exc) is empty, the error label is just the class name."""
+    monkeypatch.delenv("OPENCHRONICLE_LLM_MOCK", raising=False)
+    import litellm
+
+    class Timeout(Exception):
+        pass
+
+    def boom(**kwargs):
+        raise Timeout()
+
+    monkeypatch.setattr(litellm, "completion", boom)
+    cfg = _cfg_with_model()
+
+    res = llm_mod.ping_stage(cfg, "compact")
+
+    assert res.ok is False
+    assert res.error == "Timeout"
+
+
+def test_ping_stage_truncates_long_error_message(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Error labels are capped so a verbose provider message can't blow up status output."""
+    monkeypatch.delenv("OPENCHRONICLE_LLM_MOCK", raising=False)
+    import litellm
+
+    class ProviderError(Exception):
+        pass
+
+    def boom(**kwargs):
+        raise ProviderError("x" * 500)
+
+    monkeypatch.setattr(litellm, "completion", boom)
+    cfg = _cfg_with_model()
+
+    res = llm_mod.ping_stage(cfg, "timeline")
+
+    assert res.ok is False
+    assert res.error is not None
+    assert len(res.error) <= 80


### PR DESCRIPTION
## Summary

Today `openchronicle status` echoes the resolved model name for each of the four LLM stages (`timeline`, `reducer`, `classifier`, `compact`) but never actually contacts the provider. A typo in `[models.classifier].model`, a missing `OPENAI_API_KEY`, an unreachable `base_url` (e.g. local Ollama not running), or a key without permissions all silently look fine in `status` — the failure only surfaces hours later in `~/.openchronicle/logs/writer.log`, after the daemon has already eaten captures and produced no memory.

This change makes `status` send a tiny round-trip to each stage and render the result inline:

```
Model (timeline)    gpt-5.4-nano        ✓ 234 ms
Model (reducer)     claude-haiku-4-5    ✗ AuthenticationError: …
```

Misconfigurations now surface on the first `status` call.

## Design

- **`ping_stage(cfg, stage, *, timeout=5.0)`** in `src/openchronicle/writer/llm.py` — `max_tokens=4`, 5s litellm-native timeout, never raises (returns `PingResult(ok=False, error="<ErrorClass>: …")`). Honors `OPENCHRONICLE_LLM_MOCK=1` for offline / CI runs.
- **Dedup in `status()`** — pings keyed by `(model, base_url, resolved_api_key)`. Common case (one model for all four stages) makes one network call, not four.


- **Parallel** — `ThreadPoolExecutor(max_workers=4)` so a single hung provider can't stretch `status` past the per-call timeout.
- **Status stays informational** — failures render as `✗` cells but the command always exits 0; a probe failure never crashes `status`.

## Out of scope

- No new `openchronicle models test` subcommand — folded into `status` per the design discussion.
- No retries / backoff — a single 5s probe is enough to distinguish "configured wrong" from "configured right"; transient flakes will recover on the next `status`.
- No JSON output mode for `status`.

## Test plan

- [x] `uv run pytest` — full suite, 71 passed (2 new in `tests/test_cli_status.py`).
- [x] `uv run ruff check` on changed files — clean.
- [x] `OPENCHRONICLE_LLM_MOCK=1 openchronicle status` → all four stages render `✓ mocked`, no network calls.
- [x] `OPENAI_API_KEY=bogus openchronicle status` → all four stages render `✗ AuthenticationError: …`, exit 0.
- [x] `openchronicle status` with valid key → renders `✓ <latency> ms` per stage.


<img width="830" height="377" alt="Screenshot 2026-04-25 at 4 56 23 PM" src="https://github.com/user-attachments/assets/b2c4ccc1-37e5-45be-9d92-c98d07e05ca9" />
🤖 Generated with [Claude Code](https://claude.com/claude-code)