### PR TITLE
fix(store): atomic writes for memory files

### DIFF
--- a/src/openchronicle/store/entries.py
+++ b/src/openchronicle/store/entries.py
@@ -104,7 +104,7 @@ def append_entry(
             logger.info("flagged %s for compact (est %d tokens > %d)",
                         path.name, est_tokens, soft_limit_tokens)
 
-    path.write_text(frontmatter.dumps(post) + "\n")
+    files_mod.atomic_write_text(path, frontmatter.dumps(post) + "\n")
 
     # Update FTS
     fts.insert_entry(
@@ -179,13 +179,13 @@ def supersede_entry(
     if not text.endswith("\n"):
         text += "\n"
     text += new_block
-    path.write_text(text)
+    files_mod.atomic_write_text(path, text)
 
     # Rebuild frontmatter counts (re-parse to be safe)
     post = frontmatter.load(path)
     post.metadata["entry_count"] = int(post.metadata.get("entry_count", 0)) + 1
     post.metadata["updated"] = files_mod.today()
-    path.write_text(frontmatter.dumps(post) + "\n")
+    files_mod.atomic_write_text(path, frontmatter.dumps(post) + "\n")
 
     # FTS
     fts.mark_superseded(conn, old_entry_id)

--- a/src/openchronicle/store/entries.py
+++ b/src/openchronicle/store/entries.py
@@ -179,10 +179,14 @@ def supersede_entry(
     if not text.endswith("\n"):
         text += "\n"
     text += new_block
-    files_mod.atomic_write_text(path, text)
 
-    # Rebuild frontmatter counts (re-parse to be safe)
-    post = frontmatter.load(path)
+    # Fold the metadata bump (entry_count, updated) into a SINGLE write.
+    # The earlier two-write shape — write the new text, reload from
+    # disk, write again with bumped metadata — left a window in which
+    # a crash between writes would persist the new content with stale
+    # frontmatter. ``frontmatter.loads`` re-parses the in-memory text
+    # we just built, so the second-write reload is unnecessary.
+    post = frontmatter.loads(text)
     post.metadata["entry_count"] = int(post.metadata.get("entry_count", 0)) + 1
     post.metadata["updated"] = files_mod.today()
     files_mod.atomic_write_text(path, frontmatter.dumps(post) + "\n")

--- a/src/openchronicle/store/files.py
+++ b/src/openchronicle/store/files.py
@@ -2,7 +2,10 @@
 
 from __future__ import annotations
 
+import contextlib
+import os
 import re
+import tempfile
 from dataclasses import dataclass, field
 from datetime import date
 from pathlib import Path
@@ -11,6 +14,45 @@ from typing import Any
 import frontmatter
 
 from .. import paths
+
+
+def atomic_write_text(path: Path, content: str) -> None:
+    """Write ``content`` to ``path`` atomically.
+
+    A crash between writing the temp file and the rename leaves the
+    original file untouched; a crash after the rename leaves the new
+    file fully written. ``os.replace`` is atomic on POSIX (and on
+    Windows for files on the same volume). The temp file lives in the
+    target's parent directory so the rename is a same-filesystem move.
+
+    Without this, a daemon SIGKILL / OOM / power loss in the middle of
+    ``Path.write_text`` truncates the file — frontmatter or entry text
+    half-written, the next read fails to parse.
+
+    Permissions are preserved when overwriting an existing file.
+    Newly created files keep ``mkstemp``'s 0o600 default — which is
+    appropriate for private memory data; the previous code path
+    inherited the umask default (typically 0o644).
+    """
+    path.parent.mkdir(parents=True, exist_ok=True)
+    fd, tmp_name = tempfile.mkstemp(
+        dir=path.parent, prefix=f".{path.name}.", suffix=".tmp"
+    )
+    tmp_path = Path(tmp_name)
+    try:
+        with os.fdopen(fd, "w", encoding="utf-8") as f:
+            f.write(content)
+            f.flush()
+            os.fsync(f.fileno())
+        # Preserve permissions of the existing file so updates don't
+        # silently flip group/other-read bits set by the user.
+        with contextlib.suppress(FileNotFoundError):
+            os.chmod(tmp_path, path.stat().st_mode & 0o7777)
+        os.replace(tmp_path, path)
+    except BaseException:
+        with contextlib.suppress(OSError):
+            tmp_path.unlink()
+        raise
 
 VALID_PREFIXES = ("user-", "project-", "tool-", "topic-", "person-", "org-", "event-")
 
@@ -81,8 +123,8 @@ def default_frontmatter(*, description: str, tags: list[str]) -> dict[str, Any]:
 
 def write_file(path: Path, fm: dict[str, Any], body: str) -> None:
     post = frontmatter.Post(content=body, **fm)
-    path.parent.mkdir(parents=True, exist_ok=True)
-    path.write_text(frontmatter.dumps(post) + ("\n" if not body.endswith("\n") else ""))
+    text = frontmatter.dumps(post) + ("\n" if not body.endswith("\n") else "")
+    atomic_write_text(path, text)
 
 
 def read_file(path: Path) -> ParsedFile:
@@ -156,7 +198,7 @@ def render_file(
 def update_frontmatter(path: Path, updates: dict[str, Any]) -> None:
     post = frontmatter.load(path)
     post.metadata.update(updates)
-    path.write_text(frontmatter.dumps(post) + "\n")
+    atomic_write_text(path, frontmatter.dumps(post) + "\n")
 
 
 def list_memory_files() -> list[Path]:

--- a/src/openchronicle/store/files.py
+++ b/src/openchronicle/store/files.py
@@ -49,6 +49,17 @@ def atomic_write_text(path: Path, content: str) -> None:
         with contextlib.suppress(FileNotFoundError):
             os.chmod(tmp_path, path.stat().st_mode & 0o7777)
         os.replace(tmp_path, path)
+        # Persist the directory entry so a power loss right after the
+        # rename can't leave the dir pointing at neither old nor new.
+        # macOS APFS sometimes returns EINVAL on directory fsync; the
+        # call is best-effort — failure here is strictly less safe than
+        # success, never less safe than skipping.
+        with contextlib.suppress(OSError):
+            dir_fd = os.open(path.parent, os.O_RDONLY)
+            try:
+                os.fsync(dir_fd)
+            finally:
+                os.close(dir_fd)
     except BaseException:
         with contextlib.suppress(OSError):
             tmp_path.unlink()

--- a/src/openchronicle/store/index_md.py
+++ b/src/openchronicle/store/index_md.py
@@ -6,6 +6,7 @@ import sqlite3
 from datetime import date, datetime, timedelta
 
 from .. import paths
+from . import files as files_mod
 from . import fts
 
 
@@ -76,8 +77,7 @@ def rebuild(conn: sqlite3.Connection) -> None:
         lines.append("_(none)_")
     lines.append("")
 
-    paths.memory_dir().mkdir(parents=True, exist_ok=True)
-    (paths.memory_dir() / "index.md").write_text("\n".join(lines))
+    files_mod.atomic_write_text(paths.memory_dir() / "index.md", "\n".join(lines))
 
 
 def auto_dormant(conn: sqlite3.Connection, *, days: int = 30) -> int:

--- a/src/openchronicle/writer/compact.py
+++ b/src/openchronicle/writer/compact.py
@@ -93,7 +93,9 @@ def compact_file(cfg: Config, conn: sqlite3.Connection, *, name: str) -> Compact
         )
 
     # Accept: write back, clear flag, update FTS by doing per-file rebuild
-    path.write_text(new_text if new_text.endswith("\n") else new_text + "\n")
+    files_mod.atomic_write_text(
+        path, new_text if new_text.endswith("\n") else new_text + "\n"
+    )
 
     # Re-ingest this file's entries into FTS
     fts.delete_entries_for(conn, path.name)

--- a/tests/test_store.py
+++ b/tests/test_store.py
@@ -1,11 +1,19 @@
+import os
 from pathlib import Path
+from unittest.mock import patch
 
 import pytest
 
-from openchronicle.store import entries as entries_mod
-from openchronicle.store import files as files_mod
-from openchronicle.store import fts
-from openchronicle.store import index_md
+from openchronicle.store import (
+    entries as entries_mod,
+)
+from openchronicle.store import (
+    files as files_mod,
+)
+from openchronicle.store import (
+    fts,
+    index_md,
+)
 
 
 def test_make_id_uniqueness() -> None:
@@ -69,11 +77,10 @@ def test_supersede_filters_old_by_default(ac_root: Path) -> None:
 
 
 def test_invalid_prefix_rejected(ac_root: Path) -> None:
-    with fts.cursor() as conn:
-        with pytest.raises(ValueError):
-            entries_mod.create_file(
-                conn, name="random-notes.md", description="desc", tags=[]
-            )
+    with fts.cursor() as conn, pytest.raises(ValueError):
+        entries_mod.create_file(
+            conn, name="random-notes.md", description="desc", tags=[]
+        )
 
 
 def test_rebuild_index_round_trip(ac_root: Path) -> None:
@@ -108,3 +115,74 @@ def test_index_md_rebuild_runs(ac_root: Path) -> None:
     out = (paths.memory_dir() / "index.md").read_text()
     assert "# Memory Index" in out
     assert "user-profile.md" in out
+
+
+def test_atomic_write_preserves_original_on_replace_failure(tmp_path: Path) -> None:
+    """Simulating a crash at the rename step must leave the file intact.
+
+    A SIGKILL between ``write_text``'s first byte and last byte truncates
+    the file under the previous code; under ``atomic_write_text`` the
+    rename is the only externally-visible step so a failure there leaves
+    the original content untouched and any temp file cleaned up.
+    """
+    target = tmp_path / "memory.md"
+    original = "ORIGINAL CONTENT\nline 2\n"
+    target.write_text(original)
+
+    real_replace = os.replace
+    boom = OSError("simulated rename failure")
+    with (
+        patch("openchronicle.store.files.os.replace", side_effect=boom),
+        pytest.raises(OSError),
+    ):
+        files_mod.atomic_write_text(target, "NEW CONTENT THAT NEVER LANDS")
+
+    assert target.read_text() == original
+    # No leftover .tmp files
+    leftovers = [p for p in tmp_path.iterdir() if p.name != "memory.md"]
+    assert leftovers == [], f"unexpected leftover files: {leftovers}"
+
+    # Sanity: a normal call still works once we restore replace
+    assert os.replace is real_replace
+    files_mod.atomic_write_text(target, "NEW CONTENT")
+    assert target.read_text() == "NEW CONTENT"
+
+
+def test_atomic_write_creates_parent_directory(tmp_path: Path) -> None:
+    nested = tmp_path / "nested" / "dir" / "file.md"
+    files_mod.atomic_write_text(nested, "hello")
+    assert nested.read_text() == "hello"
+
+
+def test_atomic_write_preserves_existing_permissions(tmp_path: Path) -> None:
+    """Overwriting must not silently downgrade an existing file's mode.
+
+    ``tempfile.mkstemp`` creates files at 0o600 — without explicit
+    chmod the rename would replace a user's 0o644 file with a 0o600
+    one, a hidden behavior change from ``Path.write_text``.
+    """
+    target = tmp_path / "memory.md"
+    target.write_text("original")
+    target.chmod(0o644)
+
+    files_mod.atomic_write_text(target, "updated")
+
+    assert target.read_text() == "updated"
+    assert (target.stat().st_mode & 0o777) == 0o644
+
+
+def test_atomic_write_round_trip_through_append_entry(ac_root: Path) -> None:
+    """End-to-end: append → read returns the new entry, file isn't corrupted."""
+    with fts.cursor() as conn:
+        entries_mod.create_file(
+            conn, name="topic-rust-async.md",
+            description="Rust async patterns", tags=["topic"],
+        )
+        entries_mod.append_entry(
+            conn, name="topic-rust-async.md",
+            content="Tokio's `select!` polls all branches each iteration.",
+            tags=["topic", "rust"],
+        )
+    parsed = files_mod.read_file(files_mod.memory_path("topic-rust-async.md"))
+    assert len(parsed.entries) == 1
+    assert "Tokio" in parsed.entries[0].body


### PR DESCRIPTION
## Summary

A daemon SIGKILL / OOM / power loss in the middle of `Path.write_text` truncates the target memory file — frontmatter or entry text half-written, the next `frontmatter.load` then fails to parse and the file is effectively bricked. The storage layer has six write call-sites with this exposure (`append_entry`, `supersede_entry`'s two writes, `write_file`, `update_frontmatter`, `compact`'s rewrite, and `index.md` rebuild); none used a temp-file + rename.

This PR adds `files.atomic_write_text(path, content)` and routes all six sites through it. The helper writes to `.<name>.<rand>.tmp` in the target's parent dir, `fsync`s, then `os.replace`s. POSIX guarantees the rename is atomic. Crash before it → original untouched. Crash after it → new file fully written. Tmp is cleaned up on any exception.

As a side benefit, concurrent readers no longer see truncated state mid-write.

## Behavior change worth flagging

`tempfile.mkstemp` creates files at `0o600`. To avoid silently downgrading user-set permissions on **existing** files, the helper chmods the temp to match the target's mode before renaming. **Newly created** files keep mkstemp's `0o600` — slightly stricter than the umask-default `0o644` the previous code inherited. This is appropriate for private memory data, but flagging in case you'd rather match the old default; happy to change.

## Out of scope

`capture-buffer/*.json` writes (`capture/scheduler.py`) are intentionally left as `Path.write_text` — captures are corruption-tolerant by design (the aggregator drops files that fail to `json.loads`), unlike memory files. Same for `pid`, `paused`, and config writes which are either rare or non-critical.

## Concurrency note

This PR doesn't address the concurrent-writer race (two reducer threads doing read-modify-write on the same file → silent data loss; both writes succeed, second wins). That's a separate concern fixed by per-path locking; filing as a follow-up PR so each can be reviewed in isolation.

## Test plan

- [x] `uv run pytest` — 73/73 pass (69 existing + 4 new)
- [x] `uv run ruff check src/ tests/test_store.py` — clean
- New tests:
  - `test_atomic_write_preserves_original_on_replace_failure` — patches `os.replace` to raise, asserts original content intact + no temp leftover
  - `test_atomic_write_creates_parent_directory`
  - `test_atomic_write_preserves_existing_permissions` — guards the permission-preservation contract
  - `test_atomic_write_round_trip_through_append_entry` — end-to-end through `append_entry`