### PR TITLE
fix(store): per-path lock for concurrent memory-file writes

### DIFF
--- a/src/openchronicle/store/entries.py
+++ b/src/openchronicle/store/entries.py
@@ -46,25 +46,29 @@ def create_file(
         raise ValueError("description is required")
     prefix = _ensure_prefix(name)
     path = files_mod.memory_path(name)
-    if path.exists():
-        raise FileExistsError(f"{path.name} already exists")
+    # Lock around the exists-check + write so two concurrent classifiers
+    # deciding to create the same file don't both pass the check and have
+    # the second clobber the first's freshly written content.
+    with files_mod.file_lock(path):
+        if path.exists():
+            raise FileExistsError(f"{path.name} already exists")
 
-    fm = files_mod.default_frontmatter(description=description, tags=tags)
-    files_mod.write_file(path, fm, body="")
-    fts.upsert_file(
-        conn,
-        fts.FileRow(
-            path=path.name,
-            prefix=prefix,
-            description=description,
-            tags=" ".join(tags),
-            status="active",
-            entry_count=0,
-            created=fm["created"],
-            updated=fm["updated"],
-            needs_compact=0,
-        ),
-    )
+        fm = files_mod.default_frontmatter(description=description, tags=tags)
+        files_mod.write_file(path, fm, body="")
+        fts.upsert_file(
+            conn,
+            fts.FileRow(
+                path=path.name,
+                prefix=prefix,
+                description=description,
+                tags=" ".join(tags),
+                status="active",
+                entry_count=0,
+                created=fm["created"],
+                updated=fm["updated"],
+                needs_compact=0,
+            ),
+        )
     logger.info("created file: %s", path.name)
     return path
 
@@ -88,49 +92,56 @@ def append_entry(
     heading = files_mod.render_heading(timestamp=ts, entry_id=entry_id, tags=tags)
     body = content.strip()
 
-    # Append to file
-    post = frontmatter.load(path)
-    current = post.content.rstrip()
-    new_block = f"\n\n{heading}\n{body}\n" if current else f"{heading}\n{body}\n"
-    post.content = current + new_block
-    post.metadata["entry_count"] = int(post.metadata.get("entry_count", 0)) + 1
-    post.metadata["updated"] = files_mod.today()
+    # Lock the read-modify-write so a concurrent classifier appending to
+    # the same file can't read the same base, append, and clobber this
+    # write — both writes claim "+1 entry" but only one entry survives
+    # while the FTS index keeps both, leaving file/index inconsistent.
+    with files_mod.file_lock(path):
+        post = frontmatter.load(path)
+        current = post.content.rstrip()
+        new_block = f"\n\n{heading}\n{body}\n" if current else f"{heading}\n{body}\n"
+        post.content = current + new_block
+        post.metadata["entry_count"] = int(post.metadata.get("entry_count", 0)) + 1
+        post.metadata["updated"] = files_mod.today()
 
-    # Soft limit check
-    if soft_limit_tokens is not None:
-        est_tokens = len(post.content) // 4
-        if est_tokens > soft_limit_tokens and not post.metadata.get("needs_compact"):
-            post.metadata["needs_compact"] = True
-            logger.info("flagged %s for compact (est %d tokens > %d)",
-                        path.name, est_tokens, soft_limit_tokens)
+        # Soft limit check
+        if soft_limit_tokens is not None:
+            est_tokens = len(post.content) // 4
+            if est_tokens > soft_limit_tokens and not post.metadata.get("needs_compact"):
+                post.metadata["needs_compact"] = True
+                logger.info("flagged %s for compact (est %d tokens > %d)",
+                            path.name, est_tokens, soft_limit_tokens)
 
-    files_mod.atomic_write_text(path, frontmatter.dumps(post) + "\n")
+        files_mod.atomic_write_text(path, frontmatter.dumps(post) + "\n")
 
-    # Update FTS
-    fts.insert_entry(
-        conn,
-        id=entry_id,
-        path=path.name,
-        prefix=prefix,
-        timestamp=ts,
-        tags=" ".join(tags),
-        content=body,
-        superseded=0,
-    )
-    fts.upsert_file(
-        conn,
-        fts.FileRow(
+        # Update FTS inside the lock too — a concurrent appender that
+        # observes the file post-write must also observe the matching
+        # FTS row, otherwise rebuild_index sees a row pointing at an
+        # entry that "doesn't exist" until the second writer commits.
+        fts.insert_entry(
+            conn,
+            id=entry_id,
             path=path.name,
             prefix=prefix,
-            description=str(post.metadata.get("description", "")),
-            tags=" ".join(post.metadata.get("tags", []) or []),
-            status=str(post.metadata.get("status", "active")),
-            entry_count=int(post.metadata.get("entry_count", 0)),
-            created=str(post.metadata.get("created", "")),
-            updated=str(post.metadata.get("updated", "")),
-            needs_compact=1 if post.metadata.get("needs_compact") else 0,
-        ),
-    )
+            timestamp=ts,
+            tags=" ".join(tags),
+            content=body,
+            superseded=0,
+        )
+        fts.upsert_file(
+            conn,
+            fts.FileRow(
+                path=path.name,
+                prefix=prefix,
+                description=str(post.metadata.get("description", "")),
+                tags=" ".join(post.metadata.get("tags", []) or []),
+                status=str(post.metadata.get("status", "active")),
+                entry_count=int(post.metadata.get("entry_count", 0)),
+                created=str(post.metadata.get("created", "")),
+                updated=str(post.metadata.get("updated", "")),
+                needs_compact=1 if post.metadata.get("needs_compact") else 0,
+            ),
+        )
     return entry_id
 
 
@@ -148,76 +159,78 @@ def supersede_entry(
     if not path.exists():
         raise FileNotFoundError(path.name)
 
-    parsed = files_mod.read_file(path)
-    target = next((e for e in parsed.entries if e.id == old_entry_id), None)
-    if target is None:
-        raise ValueError(f"entry {old_entry_id} not found in {path.name}")
+    # Same shape as append_entry: read-modify-write on a markdown file
+    # plus an FTS update. Holding the lock across both halves keeps
+    # readers from seeing a state where the file has the new entry but
+    # FTS still doesn't (or vice versa).
+    with files_mod.file_lock(path):
+        parsed = files_mod.read_file(path)
+        target = next((e for e in parsed.entries if e.id == old_entry_id), None)
+        if target is None:
+            raise ValueError(f"entry {old_entry_id} not found in {path.name}")
 
-    # Build replacement heading and body in the file
-    ts = _now_iso_minute()
-    new_id = make_id(ts)
+        # Build replacement heading and body in the file
+        ts = _now_iso_minute()
+        new_id = make_id(ts)
 
-    new_heading = files_mod.render_heading(
-        timestamp=ts, entry_id=new_id, tags=tags or target.tags
-    )
+        new_heading = files_mod.render_heading(
+            timestamp=ts, entry_id=new_id, tags=tags or target.tags
+        )
 
-    # Modify file text directly to preserve formatting
-    text = path.read_text()
-    # 1) append #superseded-by to old heading (only if not already present)
-    old_heading = target.heading_line
-    if f"superseded-by:{new_id}" not in old_heading:
-        updated_heading = old_heading.rstrip() + f" #superseded-by:{new_id}"
-        text = text.replace(old_heading, updated_heading, 1)
-    # 2) wrap old body in ~~...~~ (only if not already)
-    if target.body and not target.body.startswith("~~"):
-        striked = "~~" + target.body.strip() + "~~"
-        text = text.replace(target.body, striked, 1)
+        # Modify file text directly to preserve formatting
+        text = path.read_text()
+        # 1) append #superseded-by to old heading (only if not already present)
+        old_heading = target.heading_line
+        if f"superseded-by:{new_id}" not in old_heading:
+            updated_heading = old_heading.rstrip() + f" #superseded-by:{new_id}"
+            text = text.replace(old_heading, updated_heading, 1)
+        # 2) wrap old body in ~~...~~ (only if not already)
+        if target.body and not target.body.startswith("~~"):
+            striked = "~~" + target.body.strip() + "~~"
+            text = text.replace(target.body, striked, 1)
 
-    # 3) Append the new entry at the end
-    body = new_content.strip()
-    new_block = f"\n\n{new_heading}\n{body}\n<!-- supersedes: {old_entry_id}; reason: {reason} -->\n"
-    if not text.endswith("\n"):
-        text += "\n"
-    text += new_block
+        # 3) Append the new entry at the end
+        body = new_content.strip()
+        new_block = f"\n\n{new_heading}\n{body}\n<!-- supersedes: {old_entry_id}; reason: {reason} -->\n"
+        if not text.endswith("\n"):
+            text += "\n"
+        text += new_block
 
-    # Fold the metadata bump (entry_count, updated) into a SINGLE write.
-    # The earlier two-write shape — write the new text, reload from
-    # disk, write again with bumped metadata — left a window in which
-    # a crash between writes would persist the new content with stale
-    # frontmatter. ``frontmatter.loads`` re-parses the in-memory text
-    # we just built, so the second-write reload is unnecessary.
-    post = frontmatter.loads(text)
-    post.metadata["entry_count"] = int(post.metadata.get("entry_count", 0)) + 1
-    post.metadata["updated"] = files_mod.today()
-    files_mod.atomic_write_text(path, frontmatter.dumps(post) + "\n")
+        # Fold the metadata bump (entry_count, updated) into a SINGLE write
+        # via in-memory parse (frontmatter.loads), so the lock holds across
+        # one atomic write rather than two writes with a reload between.
+        post = frontmatter.loads(text)
+        post.metadata["entry_count"] = int(post.metadata.get("entry_count", 0)) + 1
+        post.metadata["updated"] = files_mod.today()
+        files_mod.atomic_write_text(path, frontmatter.dumps(post) + "\n")
 
-    # FTS
-    fts.mark_superseded(conn, old_entry_id)
-    prefix = _ensure_prefix(name)
-    fts.insert_entry(
-        conn,
-        id=new_id,
-        path=path.name,
-        prefix=prefix,
-        timestamp=ts,
-        tags=" ".join(tags or target.tags),
-        content=body,
-        superseded=0,
-    )
-    fts.upsert_file(
-        conn,
-        fts.FileRow(
+        # FTS
+        fts.mark_superseded(conn, old_entry_id)
+        prefix = _ensure_prefix(name)
+        fts.insert_entry(
+            conn,
+            id=new_id,
             path=path.name,
             prefix=prefix,
-            description=str(post.metadata.get("description", "")),
-            tags=" ".join(post.metadata.get("tags", []) or []),
-            status=str(post.metadata.get("status", "active")),
-            entry_count=int(post.metadata.get("entry_count", 0)),
-            created=str(post.metadata.get("created", "")),
-            updated=str(post.metadata.get("updated", "")),
-            needs_compact=1 if post.metadata.get("needs_compact") else 0,
-        ),
-    )
+            timestamp=ts,
+            tags=" ".join(tags or target.tags),
+            content=body,
+            superseded=0,
+        )
+        fts.upsert_file(
+            conn,
+            fts.FileRow(
+                path=path.name,
+                prefix=prefix,
+                description=str(post.metadata.get("description", "")),
+                tags=" ".join(post.metadata.get("tags", []) or []),
+                status=str(post.metadata.get("status", "active")),
+                entry_count=int(post.metadata.get("entry_count", 0)),
+                created=str(post.metadata.get("created", "")),
+                updated=str(post.metadata.get("updated", "")),
+                needs_compact=1 if post.metadata.get("needs_compact") else 0,
+            ),
+        )
     return new_id
 
 

--- a/src/openchronicle/store/files.py
+++ b/src/openchronicle/store/files.py
@@ -88,8 +88,14 @@ _path_locks: dict[str, threading.Lock] = {}
 
 
 def _lock_for(path: Path) -> threading.Lock:
-    """Return the threading.Lock that guards write access to ``path``."""
-    key = str(path)
+    """Return the threading.Lock that guards write access to ``path``.
+
+    Resolves the path before keying so a relative and an absolute spelling
+    of the same file map to the same lock. ``resolve(strict=False)`` works
+    on non-existent paths (the file may not be created yet) and is called
+    outside the registry lock so a slow stat doesn't stall other threads.
+    """
+    key = str(path.resolve())
     with _lock_registry_lock:
         lock = _path_locks.get(key)
         if lock is None:

--- a/src/openchronicle/store/files.py
+++ b/src/openchronicle/store/files.py
@@ -6,6 +6,8 @@ import contextlib
 import os
 import re
 import tempfile
+import threading
+from collections.abc import Iterator
 from dataclasses import dataclass, field
 from datetime import date
 from pathlib import Path
@@ -66,6 +68,41 @@ def atomic_write_text(path: Path, content: str) -> None:
         raise
 
 VALID_PREFIXES = ("user-", "project-", "tool-", "topic-", "person-", "org-", "event-")
+
+
+# Per-path mutex registry. The reducer fires from a daemon thread per
+# session, and the daily-tick + on-demand classifiers can fire in
+# parallel, so two threads can both call ``append_entry`` (or supersede)
+# on the same memory file. Without serialization the read-modify-write
+# in those functions silently loses one of the writes — both threads
+# read the same base, both write a "+1 entry" version, and the second
+# write wins. The FTS index, written outside the file, ends up holding
+# rows for entries that don't exist on disk.
+#
+# The fix is in-process (the daemon is single-process; CLI commands
+# don't write memory files), per-path (so unrelated files don't
+# serialize), and bounded (one Lock per memory file ≈ a few hundred
+# entries lifetime, dozens of bytes each).
+_lock_registry_lock = threading.Lock()
+_path_locks: dict[str, threading.Lock] = {}
+
+
+def _lock_for(path: Path) -> threading.Lock:
+    """Return the threading.Lock that guards write access to ``path``."""
+    key = str(path)
+    with _lock_registry_lock:
+        lock = _path_locks.get(key)
+        if lock is None:
+            lock = threading.Lock()
+            _path_locks[key] = lock
+        return lock
+
+
+@contextlib.contextmanager
+def file_lock(path: Path) -> Iterator[None]:
+    """Serialize concurrent writers on a single memory-file path."""
+    with _lock_for(path):
+        yield
 
 ENTRY_HEADING_RE = re.compile(
     r"^##\s*\[(?P<ts>[^\]]+)\]\s*\{id:\s*(?P<id>[a-zA-Z0-9\-]+)\}(?P<tags>[^\n]*)$",
@@ -207,9 +244,10 @@ def render_file(
 
 
 def update_frontmatter(path: Path, updates: dict[str, Any]) -> None:
-    post = frontmatter.load(path)
-    post.metadata.update(updates)
-    atomic_write_text(path, frontmatter.dumps(post) + "\n")
+    with file_lock(path):
+        post = frontmatter.load(path)
+        post.metadata.update(updates)
+        atomic_write_text(path, frontmatter.dumps(post) + "\n")
 
 
 def list_memory_files() -> list[Path]:

--- a/tests/test_store.py
+++ b/tests/test_store.py
@@ -1,19 +1,13 @@
 import os
+import threading
 from pathlib import Path
 from unittest.mock import patch
 
 import pytest
 
-from openchronicle.store import (
-    entries as entries_mod,
-)
-from openchronicle.store import (
-    files as files_mod,
-)
-from openchronicle.store import (
-    fts,
-    index_md,
-)
+from openchronicle.store import entries as entries_mod
+from openchronicle.store import files as files_mod
+from openchronicle.store import fts, index_md
 
 
 def test_make_id_uniqueness() -> None:
@@ -186,3 +180,121 @@ def test_atomic_write_round_trip_through_append_entry(ac_root: Path) -> None:
     parsed = files_mod.read_file(files_mod.memory_path("topic-rust-async.md"))
     assert len(parsed.entries) == 1
     assert "Tokio" in parsed.entries[0].body
+
+
+def test_concurrent_appends_lose_no_entries(ac_root: Path) -> None:
+    """N threads appending to the same file must all land.
+
+    Without the per-path lock, ``append_entry`` is read-modify-write:
+    each thread reads the same base, appends, and only the last writer's
+    version reaches disk — silent data loss with FTS rows pointing at
+    entries that don't exist on disk. ``threading.Barrier`` forces every
+    thread to enter the critical section as simultaneously as the OS
+    will allow, which is what makes the race deterministic enough to
+    catch in a unit test.
+    """
+    n = 30
+    name = "topic-load-test.md"
+
+    with fts.cursor() as conn:
+        entries_mod.create_file(
+            conn, name=name, description="concurrent appends", tags=["topic"]
+        )
+
+    barrier = threading.Barrier(n)
+    errors: list[BaseException] = []
+
+    def worker(i: int) -> None:
+        try:
+            barrier.wait()
+            with fts.cursor() as conn:
+                entries_mod.append_entry(
+                    conn, name=name,
+                    content=f"entry number {i:02d}",
+                    tags=["topic"],
+                )
+        except BaseException as exc:  # noqa: BLE001
+            errors.append(exc)
+
+    threads = [threading.Thread(target=worker, args=(i,)) for i in range(n)]
+    for t in threads:
+        t.start()
+    for t in threads:
+        t.join(timeout=30.0)
+
+    assert errors == [], f"workers errored: {errors}"
+
+    parsed = files_mod.read_file(files_mod.memory_path(name))
+    assert len(parsed.entries) == n, (
+        f"expected {n} entries, got {len(parsed.entries)} "
+        f"— silent loss indicates the lock is not protecting the read-modify-write"
+    )
+    bodies = {e.body for e in parsed.entries}
+    assert len(bodies) == n, "duplicate or missing entry bodies"
+    # File and FTS must agree.
+    with fts.cursor() as conn:
+        rebuilt_files, rebuilt_entries = entries_mod.rebuild_index(conn)
+        assert rebuilt_files == 1
+        assert rebuilt_entries == n
+
+
+def test_concurrent_supersede_then_append_serializes(ac_root: Path) -> None:
+    """A supersede + an append on the same file must both land cleanly.
+
+    Without the per-path lock, supersede's two-write read-modify-write
+    can interleave with an append in a way that produces a file the
+    next ``read_file`` won't even parse. With the lock, both operations
+    serialize and the resulting file has 1 superseded original + 1
+    superseder + 1 fresh append, all parseable.
+    """
+    name = "person-bob.md"
+    with fts.cursor() as conn:
+        entries_mod.create_file(conn, name=name, description="Bob", tags=["person"])
+        original = entries_mod.append_entry(
+            conn, name=name, content="Bob is at OpenAI as ML lead.", tags=["person"],
+        )
+
+    barrier = threading.Barrier(2)
+    errors: list[BaseException] = []
+
+    def supersede_worker() -> None:
+        try:
+            barrier.wait()
+            with fts.cursor() as conn:
+                entries_mod.supersede_entry(
+                    conn, name=name, old_entry_id=original,
+                    new_content="Bob moved from OpenAI to Anthropic in 2026-04.",
+                    reason="role change", tags=["person"],
+                )
+        except BaseException as exc:  # noqa: BLE001
+            errors.append(exc)
+
+    def append_worker() -> None:
+        try:
+            barrier.wait()
+            with fts.cursor() as conn:
+                entries_mod.append_entry(
+                    conn, name=name,
+                    content="Bob's preferred IDE is Cursor.",
+                    tags=["person", "preference"],
+                )
+        except BaseException as exc:  # noqa: BLE001
+            errors.append(exc)
+
+    threads = [
+        threading.Thread(target=supersede_worker),
+        threading.Thread(target=append_worker),
+    ]
+    for t in threads:
+        t.start()
+    for t in threads:
+        t.join(timeout=20.0)
+
+    assert errors == [], f"workers errored: {errors}"
+
+    parsed = files_mod.read_file(files_mod.memory_path(name))
+    # 1 superseded original + 1 superseder + 1 fresh append = 3 entries.
+    assert len(parsed.entries) == 3, (
+        f"expected 3 entries, got {len(parsed.entries)} — interleaved writes "
+        f"likely lost or corrupted one"
+    )


### PR DESCRIPTION
## Summary

The reducer fires from a daemon thread per session, and the daily-tick + on-demand classifiers can fire in parallel, so two threads can both call `append_entry` (or `supersede_entry`) on the same memory file. Without serialization, the read-modify-write inside those functions silently loses one of the writes — both threads load the same base, both `frontmatter.dumps` a "+1 entry" version, the second write wins, and the FTS index, written outside the file, ends up with rows for entries that don't exist on disk.

This adds an in-process per-path mutex (`files.file_lock(path)`) and wraps the four read-modify-write paths: `create_file`, `append_entry`, `supersede_entry`, `update_frontmatter`. The lock is:

- **In-process** — the daemon is a single process; CLI commands don't write memory files
- **Per-path** — writes to unrelated files still parallelize
- **Bounded** — one Lock per memory file lifetime, dozens of bytes each

## Out of scope (intentional)

`compact_file` is **not** locked here. Its body calls the LLM (10–60 s) and holding the lock across that would stall every other reducer touching the same file. compact's race needs a separate compare-and-swap pattern (read base → LLM → take lock → re-read → write iff base unchanged); filing as a follow-up so the design can be reviewed on its own.

## Relationship to #11

Independent of the atomic-write PR. They modify overlapping files but the changes are orthogonal:

- #11 addresses *crash mid-write → file truncated* (any kill window)
- This PR addresses *two concurrent writers → silent overwrite* (concurrent-classifier window)

Either can merge first; the other still applies cleanly.

## Test plan

- [x] `uv run pytest` — 71/71 pass
- [x] `uv run ruff check src/ tests/test_store.py` — clean
- New tests use `threading.Barrier` so they're sleep-free and deterministic:
  - `test_concurrent_appends_lose_no_entries` — 30 threads append concurrently; asserts all 30 entries land + `rebuild_index` reports 30. Without the lock this fails: file has fewer entries while FTS has 30.
  - `test_concurrent_supersede_then_append_serializes` — supersede + append on the same file in parallel; asserts the result still parses and contains the expected 3 entries.