### PR TITLE
feat(capture): add S1 app parser registry with golden fixture tests

### DIFF
--- a/src/openchronicle/capture/app_parsers/__init__.py
+++ b/src/openchronicle/capture/app_parsers/__init__.py
@@ -1,0 +1,56 @@
+"""S1 app parser registry.
+
+Parsers are registered at import time and run in priority order during
+:func:`apply_parsers`.  Later parsers can match on fields produced by
+earlier parsers (e.g. a Linear parser matching ``fields.url`` that
+contains ``linear.app``, which was extracted by the browser parser).
+"""
+
+from __future__ import annotations
+
+from ...logger import get
+from .base import AppParser, ParseContext, S1Fields
+from .browser import BrowserParser
+
+logger = get("openchronicle.capture.s1_registry")
+
+_parsers: list[AppParser] = []
+
+
+def _register_builtins() -> None:
+    register(BrowserParser())
+
+
+def register(parser: AppParser) -> None:
+    _parsers.append(parser)
+    _parsers.sort(key=lambda p: p.priority)
+
+
+def _reset_registry() -> None:
+    """Clear all registered parsers and re-register builtins.
+
+    Intended for test isolation so registry mutations in one test
+    do not leak into another.
+    """
+    _parsers.clear()
+    _register_builtins()
+
+
+def apply_parsers(ctx: ParseContext, fields: S1Fields) -> None:
+    for parser in _parsers:
+        try:
+            if parser.matches(ctx, fields):
+                patch = parser.parse(ctx, fields)
+                if patch.focused_element is not None:
+                    fields.focused_element = patch.focused_element
+                if patch.visible_text is not None:
+                    fields.visible_text = patch.visible_text
+                if patch.url is not None:
+                    fields.url = patch.url
+                if patch.app_context:
+                    fields.app_context = {**fields.app_context, **patch.app_context}
+        except Exception:
+            logger.exception("S1 parser %r failed", parser.name)
+
+
+_register_builtins()

--- a/src/openchronicle/capture/app_parsers/base.py
+++ b/src/openchronicle/capture/app_parsers/base.py
@@ -1,0 +1,94 @@
+"""Base types for the S1 app parser registry.
+
+Every app-specific parser implements the :class:`AppParser` protocol.
+The :class:`ParseContext` gives parsers read-only access to the raw
+capture data; :class:`S1Fields` holds the current state; and
+:class:`S1Patch` lets a parser selectively override fields.
+"""
+
+from __future__ import annotations
+
+from dataclasses import asdict, dataclass, field
+from typing import Any, Iterable, Protocol
+
+
+@dataclass
+class FocusedElement:
+    role: str = ""
+    title: str = ""
+    value: str = ""
+    is_editable: bool = False
+    has_value: bool = False
+    value_length: int = 0
+
+    def to_dict(self) -> dict[str, Any]:
+        d = asdict(self)
+        stripped = (self.value or "").strip()
+        d["has_value"] = bool(stripped)
+        d["value_length"] = len(stripped)
+        return d
+
+
+@dataclass
+class ParseContext:
+    """Read-only view of the raw capture data for a parser."""
+
+    capture: dict[str, Any]
+    app: dict[str, Any]
+    window_meta: dict[str, Any]
+
+    @property
+    def bundle_id(self) -> str:
+        return (self.app.get("bundle_id") or "").strip()
+
+    @property
+    def app_name(self) -> str:
+        return (self.app.get("name") or "").strip()
+
+    def iter_windows(self) -> Iterable[dict[str, Any]]:
+        return iter(self.app.get("windows", []))
+
+    def focused_window(self) -> dict[str, Any] | None:
+        for w in self.app.get("windows", []):
+            if w.get("focused"):
+                return w
+        return None
+
+    def iter_elements(self) -> Iterable[dict[str, Any]]:
+        """Iterate top-level elements across all windows."""
+        for window in self.app.get("windows", []):
+            yield from window.get("elements", [])
+
+
+@dataclass
+class S1Fields:
+    focused_element: FocusedElement
+    visible_text: str
+    url: str | None = None
+    app_context: dict[str, Any] = field(default_factory=dict)
+
+
+@dataclass
+class S1Patch:
+    focused_element: FocusedElement | None = None
+    visible_text: str | None = None
+    url: str | None = None
+    app_context: dict[str, Any] = field(default_factory=dict)
+
+
+class AppParser(Protocol):
+    """Protocol for app-specific S1 field parsers.
+
+    .. warning::
+
+        ``matches()`` and ``parse()`` **must not** call ``register()``.
+        Doing so mutates the parser list while ``apply_parsers()`` is
+        iterating and will raise a ``RuntimeError``.
+    """
+
+    name: str
+    priority: int
+
+    def matches(self, ctx: ParseContext, fields: S1Fields) -> bool: ...
+
+    def parse(self, ctx: ParseContext, fields: S1Fields) -> S1Patch: ...

--- a/src/openchronicle/capture/app_parsers/browser.py
+++ b/src/openchronicle/capture/app_parsers/browser.py
@@ -1,0 +1,52 @@
+"""Browser URL extraction parser.
+
+Migrated from ``s1_parser._extract_url``.  Matches known browser
+bundle IDs and extracts the URL from the first ``AXTextField`` whose
+value looks like a URL or bare domain.
+"""
+
+from __future__ import annotations
+
+import re
+from typing import Any
+
+from .base import ParseContext, S1Fields, S1Patch
+
+_BROWSER_BUNDLES = {
+    "com.google.Chrome",
+    "com.apple.Safari",
+    "org.mozilla.firefox",
+    "com.microsoft.edgemac",
+    "company.thebrowser.Browser",
+    "com.brave.Browser",
+    "com.operasoftware.Opera",
+}
+
+_URL_RE = re.compile(r"https?://\S+")
+
+
+class BrowserParser:
+    name = "browser"
+    priority = 10
+
+    def matches(self, ctx: ParseContext, fields: S1Fields) -> bool:
+        return ctx.bundle_id in _BROWSER_BUNDLES
+
+    def parse(self, ctx: ParseContext, fields: S1Fields) -> S1Patch:
+        url = _extract_url_from_app(ctx.app)
+        return S1Patch(url=url)
+
+
+def _extract_url_from_app(app_data: dict[str, Any]) -> str | None:
+    for window in app_data.get("windows", []):
+        for el in window.get("elements", []):
+            if el.get("role") != "AXTextField":
+                continue
+            value = (el.get("value") or "").strip()
+            if not value:
+                continue
+            if _URL_RE.search(value):
+                return value
+            if "." in value and " " not in value:
+                return f"https://{value}"
+    return None

--- a/src/openchronicle/capture/s1_parser.py
+++ b/src/openchronicle/capture/s1_parser.py
@@ -9,27 +9,28 @@ Ported from Einsia-Partner's S1 extraction (``s1_collector`` —
 ``_extract_focused_element`` / ``_render_visible_text`` / ``_extract_url``).
 Runs inline inside ``capture_once`` so every capture-buffer JSON carries
 these fields.
+
+Architecture
+------------
+
+``enrich()`` computes a **generic baseline** (focused element + visible text
++ url=None) and then runs registered app parsers in priority order.  Each
+parser may selectively override fields via an ``S1Patch``.  This lets future
+parsers compose — for example a Linear parser can match ``linear.app`` in
+the URL that the browser parser already extracted.
 """
 
 from __future__ import annotations
 
-import re
-from dataclasses import asdict, dataclass
 from typing import Any
 
+# Import triggers builtin parser registration.
+from .app_parsers import apply_parsers
+from .app_parsers.base import FocusedElement, ParseContext, S1Fields
 from .ax_models import ax_app_to_markdown
 
-_BROWSER_BUNDLES = {
-    "com.google.Chrome",
-    "com.apple.Safari",
-    "org.mozilla.firefox",
-    "com.microsoft.edgemac",
-    "company.thebrowser.Browser",
-    "com.brave.Browser",
-    "com.operasoftware.Opera",
-}
-
-_URL_RE = re.compile(r"https?://\S+")
+# Re-export for tests and downstream code that imports from here.
+__all__ = ["FocusedElement", "enrich"]
 
 _EDITABLE_ROLES = {"AXTextField", "AXTextArea", "AXComboBox"}
 _STATIC_ROLES = {"AXStaticText", "AXWebArea"}
@@ -37,23 +38,6 @@ _STATIC_ROLES = {"AXStaticText", "AXWebArea"}
 _VISIBLE_TEXT_MAX = 10_000
 _FOCUS_TITLE_MAX = 200
 _FOCUS_VALUE_MAX = 2_000
-
-
-@dataclass
-class FocusedElement:
-    role: str = ""
-    title: str = ""
-    value: str = ""
-    is_editable: bool = False
-    has_value: bool = False
-    value_length: int = 0
-
-    def to_dict(self) -> dict[str, Any]:
-        d = asdict(self)
-        stripped = (self.value or "").strip()
-        d["has_value"] = bool(stripped)
-        d["value_length"] = len(stripped)
-        return d
 
 
 def enrich(capture: dict[str, Any]) -> None:
@@ -72,9 +56,27 @@ def enrich(capture: dict[str, Any]) -> None:
         capture["url"] = None
         return
 
-    capture["focused_element"] = _extract_focused_element(app_data).to_dict()
-    capture["visible_text"] = _render_visible_text(app_data)
-    capture["url"] = _extract_url(app_data)
+    # ── Generic baseline ──────────────────────────────────────────────
+    fields = S1Fields(
+        focused_element=_extract_focused_element(app_data),
+        visible_text=_render_visible_text(app_data),
+        url=None,
+    )
+
+    # ── App-parser patches ────────────────────────────────────────────
+    ctx = ParseContext(
+        capture=capture,
+        app=app_data,
+        window_meta=capture.get("window_meta") or {},
+    )
+    apply_parsers(ctx, fields)
+
+    # ── Write back ────────────────────────────────────────────────────
+    capture["focused_element"] = fields.focused_element.to_dict()
+    capture["visible_text"] = fields.visible_text
+    capture["url"] = fields.url
+    if fields.app_context:
+        capture["app_context"] = fields.app_context
 
 
 def _frontmost_app(ax_tree: dict[str, Any]) -> dict[str, Any] | None:
@@ -113,21 +115,3 @@ def _render_visible_text(app_data: dict[str, Any]) -> str:
     if len(md) > _VISIBLE_TEXT_MAX:
         md = md[:_VISIBLE_TEXT_MAX] + "\n...(truncated)"
     return md
-
-
-def _extract_url(app_data: dict[str, Any]) -> str | None:
-    bundle = app_data.get("bundle_id", "")
-    if bundle not in _BROWSER_BUNDLES:
-        return None
-    for window in app_data.get("windows", []):
-        for el in window.get("elements", []):
-            if el.get("role") != "AXTextField":
-                continue
-            value = (el.get("value") or "").strip()
-            if not value:
-                continue
-            if _URL_RE.search(value):
-                return value
-            if "." in value and " " not in value:
-                return f"https://{value}"
-    return None

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -8,6 +8,15 @@ from pathlib import Path
 import pytest
 
 
+@pytest.fixture(autouse=True)
+def _reset_app_parser_registry() -> None:
+    """Restore builtin parsers before each test so registry mutations
+    in one test do not leak into another."""
+    from openchronicle.capture.app_parsers import _reset_registry
+
+    _reset_registry()
+
+
 @pytest.fixture
 def ac_root(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
     root = tmp_path / "openchronicle"

--- a/tests/fixtures/s1/chrome_url/expected.json
+++ b/tests/fixtures/s1/chrome_url/expected.json
@@ -1,0 +1,12 @@
+{
+  "focused_element": {
+    "role": "AXTextField",
+    "title": "Address and search bar",
+    "value": "https://www.anthropic.com/news",
+    "is_editable": true,
+    "has_value": true,
+    "value_length": 30
+  },
+  "visible_text": "## Google Chrome [active]\n_com.google.Chrome_\n### Anthropic — Claude Code\n- [TextField] Address and search bar — https://www.anthropic.com/news",
+  "url": "https://www.anthropic.com/news"
+}

--- a/tests/fixtures/s1/chrome_url/input.json
+++ b/tests/fixtures/s1/chrome_url/input.json
@@ -1,0 +1,24 @@
+{
+  "ax_tree": {
+    "apps": [
+      {
+        "name": "Google Chrome",
+        "bundle_id": "com.google.Chrome",
+        "is_frontmost": true,
+        "windows": [
+          {
+            "title": "Anthropic — Claude Code",
+            "focused": true,
+            "elements": [
+              {
+                "role": "AXTextField",
+                "title": "Address and search bar",
+                "value": "https://www.anthropic.com/news"
+              }
+            ]
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/tests/fixtures/s1/generic_cursor_textarea/expected.json
+++ b/tests/fixtures/s1/generic_cursor_textarea/expected.json
@@ -1,0 +1,12 @@
+{
+  "focused_element": {
+    "role": "AXTextArea",
+    "title": "editor",
+    "value": "def enrich(capture):\n    ...",
+    "is_editable": true,
+    "has_value": true,
+    "value_length": 28
+  },
+  "visible_text": "## Cursor [active]\n_com.todesktop.230313mzl4w4u92_\n### s1_parser.py\n- [TextArea] editor — def enrich(capture):\n    ...",
+  "url": null
+}

--- a/tests/fixtures/s1/generic_cursor_textarea/input.json
+++ b/tests/fixtures/s1/generic_cursor_textarea/input.json
@@ -1,0 +1,24 @@
+{
+  "ax_tree": {
+    "apps": [
+      {
+        "name": "Cursor",
+        "bundle_id": "com.todesktop.230313mzl4w4u92",
+        "is_frontmost": true,
+        "windows": [
+          {
+            "title": "s1_parser.py",
+            "focused": true,
+            "elements": [
+              {
+                "role": "AXTextArea",
+                "title": "editor",
+                "value": "def enrich(capture):\n    ..."
+              }
+            ]
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/tests/fixtures/s1/non_browser_url_textfield/expected.json
+++ b/tests/fixtures/s1/non_browser_url_textfield/expected.json
@@ -1,0 +1,12 @@
+{
+  "focused_element": {
+    "role": "AXTextField",
+    "title": "",
+    "value": "https://example.com",
+    "is_editable": true,
+    "has_value": true,
+    "value_length": 19
+  },
+  "visible_text": "## Notes [active]\n_com.apple.Notes_\n### Notes\n- [TextField] https://example.com",
+  "url": null
+}

--- a/tests/fixtures/s1/non_browser_url_textfield/input.json
+++ b/tests/fixtures/s1/non_browser_url_textfield/input.json
@@ -1,0 +1,23 @@
+{
+  "ax_tree": {
+    "apps": [
+      {
+        "name": "Notes",
+        "bundle_id": "com.apple.Notes",
+        "is_frontmost": true,
+        "windows": [
+          {
+            "title": "Notes",
+            "focused": true,
+            "elements": [
+              {
+                "role": "AXTextField",
+                "value": "https://example.com"
+              }
+            ]
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/tests/fixtures/s1/safari_bare_domain/expected.json
+++ b/tests/fixtures/s1/safari_bare_domain/expected.json
@@ -1,0 +1,12 @@
+{
+  "focused_element": {
+    "role": "AXTextField",
+    "title": "",
+    "value": "anthropic.com",
+    "is_editable": true,
+    "has_value": true,
+    "value_length": 13
+  },
+  "visible_text": "## Safari [active]\n_com.apple.Safari_\n### \n- [TextField] anthropic.com",
+  "url": "https://anthropic.com"
+}

--- a/tests/fixtures/s1/safari_bare_domain/input.json
+++ b/tests/fixtures/s1/safari_bare_domain/input.json
@@ -1,0 +1,23 @@
+{
+  "ax_tree": {
+    "apps": [
+      {
+        "name": "Safari",
+        "bundle_id": "com.apple.Safari",
+        "is_frontmost": true,
+        "windows": [
+          {
+            "title": "",
+            "focused": true,
+            "elements": [
+              {
+                "role": "AXTextField",
+                "value": "anthropic.com"
+              }
+            ]
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/tests/test_s1_golden.py
+++ b/tests/test_s1_golden.py
@@ -1,0 +1,47 @@
+"""Golden fixture tests for S1 parser output.
+
+Each fixture directory under ``tests/fixtures/s1`` contains an
+``input.json`` (a minimal capture object) and an ``expected.json``
+(the expected S1 output fields).  The test calls ``s1_parser.enrich``
+and compares only the S1 fields.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from openchronicle.capture import s1_parser
+
+FIXTURES_DIR = Path(__file__).parent / "fixtures" / "s1"
+
+
+def _read_json(path: Path) -> dict:
+    return json.loads(path.read_text())
+
+
+def _fixture_ids() -> list[str]:
+    return sorted(
+        d.name for d in FIXTURES_DIR.iterdir() if d.is_dir()
+    )
+
+
+@pytest.mark.parametrize("name", _fixture_ids())
+def test_s1_golden(name: str) -> None:
+    fixture_dir = FIXTURES_DIR / name
+    input_capture = _read_json(fixture_dir / "input.json")
+    expected = _read_json(fixture_dir / "expected.json")
+
+    s1_parser.enrich(input_capture)
+
+    actual: dict = {
+        "focused_element": input_capture.get("focused_element"),
+        "visible_text": input_capture.get("visible_text"),
+        "url": input_capture.get("url"),
+    }
+    if "app_context" in input_capture:
+        actual["app_context"] = input_capture["app_context"]
+
+    assert actual == expected

--- a/tests/test_s1_golden.py
+++ b/tests/test_s1_golden.py
@@ -19,7 +19,7 @@ FIXTURES_DIR = Path(__file__).parent / "fixtures" / "s1"
 
 
 def _read_json(path: Path) -> dict:
-    return json.loads(path.read_text())
+    return json.loads(path.read_bytes())
 
 
 def _fixture_ids() -> list[str]:

--- a/tests/test_s1_integration.py
+++ b/tests/test_s1_integration.py
@@ -94,7 +94,7 @@ def test_scheduler_enrich_pipeline_writes_s1_fields(
     assert path is not None
     assert path.exists()
 
-    data = json.loads(path.read_text())
+    data = json.loads(path.read_bytes())
 
     # S1 baseline fields are present.
     assert data.get("url") == "https://www.anthropic.com/news"
@@ -176,7 +176,7 @@ def test_scheduler_non_browser_no_url_in_index(ac_root: Path, monkeypatch) -> No
     path = sched_mod.capture_once(cfg, CursorProvider())
 
     assert path is not None
-    data = json.loads(path.read_text())
+    data = json.loads(path.read_bytes())
     assert data.get("url") is None
 
 

--- a/tests/test_s1_integration.py
+++ b/tests/test_s1_integration.py
@@ -1,0 +1,271 @@
+"""Integration tests for the S1 enrichment pipeline.
+
+Verifies the contract between ``s1_parser``, the capture scheduler,
+FTS indexing, and timeline event formatting.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from openchronicle.capture import scheduler as sched_mod
+from openchronicle.capture.ax_models import AXCaptureResult
+from openchronicle.capture.window_meta import WindowMeta
+from openchronicle.config import CaptureConfig
+from openchronicle.store import fts as fts_store
+from openchronicle.timeline import aggregator
+
+
+# ── Shared fixture data ──────────────────────────────────────────────
+
+_CHROME_AX_TREE = {
+    "apps": [
+        {
+            "name": "Google Chrome",
+            "bundle_id": "com.google.Chrome",
+            "is_frontmost": True,
+            "windows": [
+                {
+                    "title": "Anthropic",
+                    "focused": True,
+                    "elements": [
+                        {
+                            "role": "AXTextField",
+                            "title": "Address and search bar",
+                            "value": "https://www.anthropic.com/news",
+                        }
+                    ],
+                }
+            ],
+        }
+    ],
+    "timestamp": "2026-04-27T10:00:00+08:00",
+}
+
+
+class _FakeAXProvider:
+    """An AXProvider that always returns the same fixture tree."""
+
+    @property
+    def available(self) -> bool:
+        return True
+
+    def capture_frontmost(self, *, focused_window_only: bool = True):
+        return AXCaptureResult(
+            raw_json=_CHROME_AX_TREE,
+            timestamp=_CHROME_AX_TREE["timestamp"],
+            apps=_CHROME_AX_TREE["apps"],
+            metadata={"mode": "frontmost"},
+        )
+
+    def capture_all_visible(self):
+        return None
+
+    def capture_app(self, app_name: str, *, focused_window_only: bool = True):
+        return None
+
+
+# ── Scheduler ↔ S1 contract ─────────────────────────────────────────
+
+
+def test_scheduler_enrich_pipeline_writes_s1_fields(
+    ac_root: Path, monkeypatch
+) -> None:
+    """``capture_once`` writes a capture JSON with correct S1 fields
+    and indexes them in FTS for search."""
+    monkeypatch.setattr(
+        "openchronicle.capture.window_meta.active_window",
+        lambda: WindowMeta(
+            app_name="Google Chrome",
+            title="Anthropic",
+            bundle_id="com.google.Chrome",
+        ),
+    )
+    monkeypatch.setattr(
+        "openchronicle.capture.screenshot.grab",
+        lambda **kw: None,
+    )
+
+    cfg = CaptureConfig(include_screenshot=False)
+    provider = _FakeAXProvider()
+    path = sched_mod.capture_once(cfg, provider)
+
+    assert path is not None
+    assert path.exists()
+
+    data = json.loads(path.read_text())
+
+    # S1 baseline fields are present.
+    assert data.get("url") == "https://www.anthropic.com/news"
+    fe = data.get("focused_element") or {}
+    assert fe.get("role") == "AXTextField"
+    assert "visible_text" in data
+
+    # FTS search finds the indexed S1 fields.
+    with fts_store.cursor() as conn:
+        hits = fts_store.search_captures(conn, query="anthropic")
+        assert len(hits) >= 1
+        assert hits[0].url == "https://www.anthropic.com/news"
+        assert hits[0].app_name == "Google Chrome"
+
+    # S1 fields contribute to the content fingerprint (dedup hash).
+    fingerprint = sched_mod._content_fingerprint(data)
+    assert len(fingerprint) == 64  # SHA-256 hex digest
+
+
+def test_scheduler_non_browser_no_url_in_index(ac_root: Path, monkeypatch) -> None:
+    """A non-browser app capture has ``url=None``, indexed as empty string."""
+    non_browser_tree = {
+        "apps": [
+            {
+                "name": "Cursor",
+                "bundle_id": "com.todesktop.230313mzl4w4u92",
+                "is_frontmost": True,
+                "windows": [
+                    {
+                        "title": "main.py",
+                        "focused": True,
+                        "elements": [
+                            {
+                                "role": "AXTextArea",
+                                "title": "editor",
+                                "value": "def foo(): pass",
+                            }
+                        ],
+                    }
+                ],
+            }
+        ],
+        "timestamp": "2026-04-27T10:01:00+08:00",
+    }
+
+    class CursorProvider:
+        @property
+        def available(self) -> bool:
+            return True
+
+        def capture_frontmost(self, *, focused_window_only: bool = True):
+            return AXCaptureResult(
+                raw_json=non_browser_tree,
+                timestamp=non_browser_tree["timestamp"],
+                apps=non_browser_tree["apps"],
+                metadata={"mode": "frontmost"},
+            )
+
+        def capture_all_visible(self):
+            return None
+
+        def capture_app(self, app_name: str, *, focused_window_only: bool = True):
+            return None
+
+    monkeypatch.setattr(
+        "openchronicle.capture.window_meta.active_window",
+        lambda: WindowMeta(
+            app_name="Cursor",
+            title="main.py",
+            bundle_id="com.todesktop.230313mzl4w4u92",
+        ),
+    )
+    monkeypatch.setattr(
+        "openchronicle.capture.screenshot.grab",
+        lambda **kw: None,
+    )
+
+    cfg = CaptureConfig(include_screenshot=False)
+    path = sched_mod.capture_once(cfg, CursorProvider())
+
+    assert path is not None
+    data = json.loads(path.read_text())
+    assert data.get("url") is None
+
+
+# ── Timeline ↔ S1 contract ──────────────────────────────────────────
+
+
+def test_timeline_format_events_renders_s1_fields() -> None:
+    """``_format_events`` renders app name, title, URL, focused element,
+    and visible text from enriched S1 fields."""
+    from openchronicle.capture import s1_parser
+
+    # Build and enrich a minimal capture.
+    capture: dict = {
+        "timestamp": "2026-04-27T10:00:00+08:00",
+        "schema_version": 2,
+        "window_meta": {
+            "app_name": "Google Chrome",
+            "title": "Anthropic",
+            "bundle_id": "com.google.Chrome",
+        },
+        "ax_tree": _CHROME_AX_TREE,
+    }
+    s1_parser.enrich(capture)
+
+    # Fake a parsed list as _format_events expects.
+    parsed: list[tuple[Path, dict]] = [
+        (Path("/tmp/test.json"), capture),
+    ]
+    events_text, apps_used = aggregator._format_events(parsed)
+
+    # App name and title are rendered.
+    assert "Google Chrome" in events_text
+    assert "Anthropic" in events_text
+
+    # URL is tagged with (URL: ...).
+    assert "(URL: https://www.anthropic.com/news)" in events_text
+
+    # Focused element role and value appear.
+    assert "[AXTextField]" in events_text
+    assert "anthropic.com" in events_text
+
+    # Visible text preview is rendered.
+    assert "|" in events_text
+
+    # Apps list is populated.
+    assert "Google Chrome" in apps_used
+
+
+def test_timeline_format_events_non_browser_no_url() -> None:
+    """Non-browser captures render without a (URL: ...) tag."""
+    from openchronicle.capture import s1_parser
+
+    capture: dict = {
+        "timestamp": "2026-04-27T10:01:00+08:00",
+        "schema_version": 2,
+        "window_meta": {
+            "app_name": "Cursor",
+            "title": "main.py",
+            "bundle_id": "com.todesktop.230313mzl4w4u92",
+        },
+        "ax_tree": {
+            "apps": [
+                {
+                    "name": "Cursor",
+                    "bundle_id": "com.todesktop.230313mzl4w4u92",
+                    "is_frontmost": True,
+                    "windows": [
+                        {
+                            "title": "main.py",
+                            "focused": True,
+                            "elements": [
+                                {
+                                    "role": "AXTextArea",
+                                    "title": "editor",
+                                    "value": "def foo(): pass",
+                                }
+                            ],
+                        }
+                    ],
+                }
+            ],
+            "timestamp": "2026-04-27T10:01:00+08:00",
+        },
+    }
+    s1_parser.enrich(capture)
+
+    parsed: list[tuple[Path, dict]] = [(Path("/tmp/test.json"), capture)]
+    events_text, apps_used = aggregator._format_events(parsed)
+
+    assert "(URL:" not in events_text
+    assert "Cursor" in apps_used
+    assert "[AXTextArea]" in events_text

--- a/tests/test_s1_registry.py
+++ b/tests/test_s1_registry.py
@@ -1,0 +1,219 @@
+"""Unit tests for the S1 app parser registry."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from openchronicle.capture.app_parsers.base import (
+    FocusedElement,
+    ParseContext,
+    S1Fields,
+    S1Patch,
+)
+from openchronicle.capture.app_parsers import apply_parsers, register
+
+
+def _capture(app: dict[str, Any]) -> dict[str, Any]:
+    return {
+        "ax_tree": {"apps": [app]},
+        "window_meta": {},
+    }
+
+
+def _ctx(app: dict[str, Any]) -> ParseContext:
+    return ParseContext(capture=_capture(app), app=app, window_meta={})
+
+
+def _fields() -> S1Fields:
+    return S1Fields(
+        focused_element=FocusedElement(),
+        visible_text="baseline text",
+        url=None,
+    )
+
+
+# ── Priority ordering ────────────────────────────────────────────────
+
+
+def test_parsers_run_in_priority_order() -> None:
+    """Higher priority (lower number) runs first; later parsers compose."""
+    calls: list[str] = []
+
+    class P1:
+        name = "p1"
+        priority = 10
+
+        def matches(self, ctx, fields):
+            calls.append("p1.match")
+            return True
+
+        def parse(self, ctx, fields):
+            calls.append("p1.parse")
+            return S1Patch(visible_text="p1")
+
+    class P2:
+        name = "p2"
+        priority = 20
+
+        def matches(self, ctx, fields):
+            calls.append("p2.match")
+            return True
+
+        def parse(self, ctx, fields):
+            calls.append("p2.parse")
+            return S1Patch(url="p2_url")
+
+    register(P1())
+    register(P2())
+
+    fields = _fields()
+    ctx = _ctx({"bundle_id": "x"})
+    apply_parsers(ctx, fields)
+
+    assert calls == ["p1.match", "p1.parse", "p2.match", "p2.parse"]
+    assert fields.visible_text == "p1"
+    assert fields.url == "p2_url"
+
+
+# ── Composition across parsers ───────────────────────────────────────
+
+
+def test_multiple_parsers_compose_patches() -> None:
+    class URLExtractor:
+        name = "url"
+        priority = 10
+
+        def matches(self, ctx, fields):
+            return True
+
+        def parse(self, ctx, fields):
+            return S1Patch(url="https://linear.app/issue/LIN-1")
+
+    class LinearMeta:
+        name = "linear"
+        priority = 20
+
+        def matches(self, ctx, fields):
+            return "linear.app" in (fields.url or "")
+
+        def parse(self, ctx, fields):
+            return S1Patch(app_context={"linear": {"issue_id": "LIN-1"}})
+
+    register(URLExtractor())
+    register(LinearMeta())
+
+    fields = _fields()
+    ctx = _ctx({"bundle_id": "com.linear"})
+    apply_parsers(ctx, fields)
+
+    assert fields.url == "https://linear.app/issue/LIN-1"
+    assert fields.app_context == {"linear": {"issue_id": "LIN-1"}}
+
+
+# ── Exception resilience ─────────────────────────────────────────────
+
+
+def test_parser_exception_does_not_break_baseline() -> None:
+    class BrokenParser:
+        name = "broken"
+        priority = 10
+
+        def matches(self, ctx, fields):
+            return True
+
+        def parse(self, ctx, fields):
+            raise RuntimeError("simulated failure")
+
+    class HealthyParser:
+        name = "healthy"
+        priority = 20
+
+        def matches(self, ctx, fields):
+            return True
+
+        def parse(self, ctx, fields):
+            return S1Patch(url="still_works")
+
+    register(BrokenParser())
+    register(HealthyParser())
+
+    fields = _fields()
+    ctx = _ctx({"bundle_id": "x"})
+    apply_parsers(ctx, fields)
+
+    # Baseline fields survive the broken parser.
+    assert fields.visible_text == "baseline text"
+    assert fields.focused_element.role == ""
+    # Healthy parser still runs after the broken one.
+    assert fields.url == "still_works"
+
+
+# ── app_context handling ─────────────────────────────────────────────
+
+
+def test_empty_app_context_not_written_to_capture() -> None:
+    """app_context is only written when non-empty."""
+    from openchronicle.capture import s1_parser
+
+    capture = {
+        "ax_tree": {
+            "apps": [
+                {
+                    "name": "App",
+                    "bundle_id": "test.app",
+                    "is_frontmost": True,
+                    "windows": [
+                        {
+                            "title": "T",
+                            "focused": True,
+                            "elements": [
+                                {"role": "AXStaticText", "value": "hello"}
+                            ],
+                        }
+                    ],
+                }
+            ]
+        }
+    }
+    s1_parser.enrich(capture)
+    assert "app_context" not in capture
+
+
+def test_non_empty_app_context_written_to_capture() -> None:
+    """app_context appears when a parser provides it."""
+    class MetadataParser:
+        name = "meta"
+        priority = 10
+
+        def matches(self, ctx, fields):
+            return True
+
+        def parse(self, ctx, fields):
+            return S1Patch(app_context={"key": "value"})
+
+    register(MetadataParser())
+
+    from openchronicle.capture import s1_parser
+
+    capture = {
+        "ax_tree": {
+            "apps": [
+                {
+                    "name": "App",
+                    "bundle_id": "test.app",
+                    "is_frontmost": True,
+                    "windows": [
+                        {
+                            "title": "T",
+                            "focused": True,
+                            "elements": [
+                                {"role": "AXStaticText", "value": "hello"}
+                            ],
+                        }
+                    ],
+                }
+            ]
+        }
+    }
+    s1_parser.enrich(capture)
+    assert capture["app_context"] == {"key": "value"}


### PR DESCRIPTION
## Summary

Introduce a lightweight, **baseline-plus-patches** parser registry for the S1 capture enrichment layer, so the project can grow from one monolithic module (`s1_parser.py`) into a family of small, independently-testable app parsers — without changing a single byte of downstream behaviour.

## Why

The current `s1_parser.enrich(capture)` merges three responsibilities in one module: generic AX→S1 extraction, browser URL extraction, and (on another branch) editor/terminal metadata. This works for a small surface area, but it does not scale as the project adds parsers for Slack, Linear, Office, Figma, Notion, terminals, and other high-value contexts.

This PR splits **infrastructure from implementation**:

### The Baseline + Patches Model

1. `enrich()` always computes a **generic baseline** (focused element, visible text, `url=None`).
2. Registered `AppParser` implementations then run in **priority order**.
3. Each parser may return an `S1Patch` that selectively overrides fields.
4. Later parsers can **compose on top of earlier ones** — e.g. a Linear parser can match `linear.app` in the URL that the browser parser already extracted.

This is intentionally **not** a first-match-wins dispatch. Composition lets an app that is both a browser AND a special-purpose tool (e.g. a browser-based IDE) get both URL extraction AND app-specific metadata.

### Benefits

- **Reviewable parsers**: golden fixture tests (`input.json` → `expected.json`) let maintainers inspect one raw AX input and one expected S1 output for each parser PR.
- **Fault isolation**: a broken parser never takes down the whole capture pipeline — exceptions are logged and the baseline fields still ship.
- **Zero downstream churn**: `focused_element`, `visible_text`, and `url` are unchanged; timeline, FTS indexing, and dedup hashing all work without modification.
- **Low ceremony for contributors**: a future parser author only needs to implement `AppParser` (4 members), register it, add a fixture directory, and open a PR.

## What Changed

### New files
| File | Purpose |
|---|---|
| `app_parsers/__init__.py` | Parser registry — `register()`, `apply_parsers()`, builtin auto-registration |
| `app_parsers/base.py` | `FocusedElement`, `ParseContext`, `S1Fields`, `S1Patch`, `AppParser` Protocol |
| `app_parsers/browser.py` | `BrowserParser` — migrated from `s1_parser._extract_url`, behaviour identical |
| `tests/test_s1_registry.py` | 5 unit tests: priority ordering, patch composition, exception resilience, `app_context` write semantics |
| `tests/test_s1_golden.py` | Parametrised golden fixture runner (4 fixtures) |
| `tests/test_s1_integration.py` | 4 integration tests: scheduler+enrich+FTS pipeline, timeline `_format_events` rendering |
| `tests/fixtures/s1/*/` | 4 fixture directories (`chrome_url`, `safari_bare_domain`, `generic_cursor_textarea`, `non_browser_url_textfield`) |

### Modified files
| File | Change |
|---|---|
| `s1_parser.py` | Remove `_BROWSER_BUNDLES`, `_extract_url`; rewrite `enrich()` as baseline + `apply_parsers()`; re-export `FocusedElement` from `base.py` |
| `tests/conftest.py` | Add `autouse` fixture to reset parser registry before each test |

### Not in this PR

- No Slack, Linear, Office, editor, or terminal parser behaviour.
- No dynamic plugin loading or entry-point discovery.
- No `schema_version` change.
- No AppleScript, browser automation, OCR, or new permissions.

## Test Plan

- [x] 9 existing `test_s1_parser.py` tests pass unchanged
- [x] 5 registry unit tests cover ordering, composition, error isolation, `app_context` semantics
- [x] 4 golden fixture tests cover browser + non-browser URL extraction scenarios
- [x] 4 integration tests cover scheduler→enrich→FTS and timeline `_format_events` contracts
- [x] Full test suite: **82/82 pass**

## Backwards Compatibility

`enrich(capture)` produces exactly the same `focused_element`, `visible_text`, and `url` values as before. Downstream consumers (timeline aggregator, FTS indexer, content-dedup hasher) require zero changes.