### PR TITLE
feat: add Android ADB MCP server

### DIFF
--- a/README_ADB_AGENT.md
+++ b/README_ADB_AGENT.md
@@ -1,0 +1,191 @@
+# OpenChronicle ADB Agent
+
+This document explains the minimal Android ADB control layer added on top of
+OpenChronicle.
+
+Architecture:
+
+```text
+Codex / Claude Code / Hermes Agent
+  -> MCP tool call
+  -> OpenChronicle ADB Control MCP Server
+  -> adb
+  -> Android device
+  -> OpenChronicle event memory
+```
+
+The original OpenChronicle memory MCP server is unchanged. The ADB server is a
+separate stdio MCP server started with:
+
+```powershell
+uv run openchronicle adb-mcp
+```
+
+## Tools
+
+The ADB MCP server exposes these tools:
+
+- `adb_list_devices`
+- `adb_screenshot`
+- `adb_dump_ui`
+- `adb_tap`
+- `adb_swipe`
+- `adb_input_text`
+- `adb_keyevent`
+- `adb_current_app`
+- `adb_open_app`
+- `adb_read_logcat`
+
+Every tool call appends an entry to OpenChronicle's daily
+`event-YYYY-MM-DD.md` memory file. Screenshots are written under:
+
+```text
+<OPENCHRONICLE_ROOT>/adb/screenshots/
+```
+
+## Safety Policy
+
+The ADB command runner denies high-risk operations before subprocess execution.
+
+Blocked by default:
+
+- `adb uninstall`
+- `adb reboot`
+- `adb root`, `adb unroot`, `adb remount`
+- `adb disable-verity`, `adb enable-verity`
+- `adb shell rm`, `adb shell rmdir`
+- `adb shell pm clear`
+- `adb shell pm uninstall`
+- `adb shell cmd package clear`
+- `adb shell cmd package uninstall`
+- `adb shell settings put/delete/reset`
+- `adb shell content delete`
+- `adb shell su`
+- `adb shell input keyevent POWER`
+- `adb shell input keyevent 26`
+
+`adb_input_text` rejects shell metacharacters and records only text length in
+memory, not the raw text.
+
+Agent operating rules:
+
+1. Call `adb_screenshot` or `adb_dump_ui` before `adb_tap`, `adb_swipe`, or
+   `adb_input_text`.
+2. Stop and ask the user before payments, login passwords, SMS codes, privacy
+   grants, account changes, or destructive workflows.
+3. Do not ask for a generic adb shell. Use the fixed tools only.
+
+## Connect a Phone
+
+1. On the Android phone, enable Developer options.
+2. Enable USB debugging.
+3. Connect the phone by USB.
+4. Accept the RSA debugging prompt on the phone.
+5. Verify from PowerShell:
+
+```powershell
+E:\ai\product\.tooling\platform-tools\adb.exe devices -l
+```
+
+Expected output:
+
+```text
+List of devices attached
+<serial> device ...
+```
+
+If the device is `unauthorized`, unlock the phone and accept the USB debugging
+prompt. If it is `offline`, unplug/replug USB or restart the adb server.
+
+## ADB Path Resolution
+
+The server looks for adb in this order:
+
+1. `OPENCHRONICLE_ADB_PATH`
+2. `ADB_PATH`
+3. `ANDROID_HOME/platform-tools`
+4. `ANDROID_SDK_ROOT/platform-tools`
+5. `PATH`
+6. local `.tooling/platform-tools` or `.tool/platform-tools` directories in the
+   current working directory or one of its parents
+
+Windows 11 example:
+
+```powershell
+$env:OPENCHRONICLE_ADB_PATH = "E:\ai\product\.tooling\platform-tools\adb.exe"
+uv run openchronicle adb-mcp
+```
+
+WSL2 example using the Windows adb.exe:
+
+```bash
+export OPENCHRONICLE_ADB_PATH=/mnt/e/ai/product/.tooling/platform-tools/adb.exe
+uv run openchronicle adb-mcp
+```
+
+Native Linux adb inside WSL2 can also work, but USB needs to be attached to WSL
+with `usbipd-win`; using Windows `adb.exe` is simpler for this MVP.
+
+## Codex / Claude / Hermes MCP Config
+
+Generic stdio MCP config:
+
+```json
+{
+  "mcpServers": {
+    "openchronicle-adb": {
+      "command": "uv",
+      "args": ["run", "openchronicle", "adb-mcp"]
+    }
+  }
+}
+```
+
+Codex CLI can also register a stdio server from the repo:
+
+```powershell
+codex mcp add openchronicle-adb -- uv run openchronicle adb-mcp
+```
+
+Claude Code can register the same stdio command:
+
+```powershell
+claude mcp add openchronicle-adb -- uv run openchronicle adb-mcp
+```
+
+Keep the existing OpenChronicle memory MCP configured separately if you also
+want memory search tools. Use `openchronicle adb-mcp` only for phone control.
+
+## Quick Self-Test
+
+Run these from the repository root:
+
+```powershell
+E:\ai\product\.tooling\platform-tools\adb.exe devices -l
+uv run pytest tests/test_adb_control.py
+uv run openchronicle adb-mcp
+```
+
+MCP client smoke test:
+
+```python
+import asyncio
+from mcp import ClientSession, StdioServerParameters
+from mcp.client.stdio import stdio_client
+
+async def main():
+    params = StdioServerParameters(
+        command="uv",
+        args=["run", "openchronicle", "adb-mcp"],
+    )
+    async with stdio_client(params) as (read, write):
+        async with ClientSession(read, write) as session:
+            await session.initialize()
+            tools = await session.list_tools()
+            print([tool.name for tool in tools.tools])
+
+asyncio.run(main())
+```
+
+To call the phone through MCP, use `adb_list_devices` first. That call should
+return the visible device list and create an `event-YYYY-MM-DD.md` memory entry.

--- a/src/openchronicle/adb/__init__.py
+++ b/src/openchronicle/adb/__init__.py
@@ -1,0 +1,12 @@
+"""Android ADB control helpers for OpenChronicle."""
+
+from .client import ADBClient, ADBCommandResult, ADBError, ADBNotFoundError
+from .tools import ADBController
+
+__all__ = [
+    "ADBClient",
+    "ADBCommandResult",
+    "ADBController",
+    "ADBError",
+    "ADBNotFoundError",
+]

--- a/src/openchronicle/adb/client.py
+++ b/src/openchronicle/adb/client.py
@@ -1,0 +1,165 @@
+"""Small, safe ADB subprocess wrapper."""
+
+from __future__ import annotations
+
+import os
+import platform
+import shutil
+import subprocess
+from collections.abc import Sequence
+from dataclasses import dataclass
+from pathlib import Path
+
+from . import safety
+
+
+class ADBError(RuntimeError):
+    """Raised when an adb subprocess fails."""
+
+    def __init__(
+        self,
+        message: str,
+        *,
+        args: Sequence[str] | None = None,
+        returncode: int | None = None,
+        stdout: str | bytes = "",
+        stderr: str = "",
+    ) -> None:
+        super().__init__(message)
+        self.args_list = list(args or [])
+        self.returncode = returncode
+        self.stdout = stdout
+        self.stderr = stderr
+
+
+class ADBNotFoundError(ADBError):
+    """Raised when no adb executable can be started."""
+
+
+@dataclass(frozen=True)
+class ADBCommandResult:
+    args: list[str]
+    returncode: int
+    stdout: str | bytes
+    stderr: str
+
+    @property
+    def stdout_text(self) -> str:
+        if isinstance(self.stdout, bytes):
+            return self.stdout.decode("utf-8", errors="replace")
+        return self.stdout
+
+    @property
+    def stdout_bytes(self) -> bytes:
+        if isinstance(self.stdout, bytes):
+            return self.stdout
+        return self.stdout.encode("utf-8")
+
+
+def _tooling_candidates() -> list[Path]:
+    names = ("adb.exe", "adb") if platform.system() == "Windows" else ("adb", "adb.exe")
+    layouts = (
+        (".tooling", "platform-tools"),
+        (".tooling", "android-sdk", "platform-tools"),
+        (".tool", "platform-tools"),
+        (".tool", "android-sdk", "platform-tools"),
+    )
+    candidates: list[Path] = []
+    for parent in (Path.cwd(), *Path.cwd().parents):
+        for layout in layouts:
+            base = parent.joinpath(*layout)
+            for name in names:
+                candidates.append(base / name)
+    return candidates
+
+
+def find_adb_path() -> str:
+    """Resolve adb from env, PATH, or a local .tooling/.tool platform-tools dir."""
+    for env_name in ("OPENCHRONICLE_ADB_PATH", "ADB_PATH"):
+        value = os.environ.get(env_name)
+        if value:
+            return str(Path(value).expanduser())
+
+    for env_name in ("ANDROID_HOME", "ANDROID_SDK_ROOT"):
+        value = os.environ.get(env_name)
+        if not value:
+            continue
+        sdk = Path(value).expanduser()
+        for name in ("adb.exe", "adb"):
+            candidate = sdk / "platform-tools" / name
+            if candidate.exists():
+                return str(candidate)
+
+    for name in ("adb.exe", "adb"):
+        found = shutil.which(name)
+        if found:
+            return found
+
+    for candidate in _tooling_candidates():
+        if candidate.exists():
+            return str(candidate)
+
+    return "adb"
+
+
+class ADBClient:
+    """Run adb commands through a single safety gate."""
+
+    def __init__(self, adb_path: str | None = None) -> None:
+        self.adb_path = adb_path or find_adb_path()
+
+    def command_for_display(self, args: Sequence[str], device_id: str | None = None) -> list[str]:
+        cmd = [self.adb_path]
+        if device_id:
+            cmd.extend(["-s", device_id])
+        cmd.extend(str(a) for a in args)
+        return cmd
+
+    def run(
+        self,
+        args: Sequence[str],
+        *,
+        device_id: str | None = None,
+        timeout: float = 30.0,
+        binary: bool = False,
+        check: bool = True,
+    ) -> ADBCommandResult:
+        safety.assert_safe([str(a) for a in args])
+        cmd = self.command_for_display(args, device_id)
+        try:
+            completed = subprocess.run(
+                cmd,
+                capture_output=True,
+                check=False,
+                timeout=timeout,
+                text=not binary,
+                encoding=None if binary else "utf-8",
+                errors=None if binary else "replace",
+            )
+        except FileNotFoundError as exc:
+            raise ADBNotFoundError(
+                f"adb executable not found: {self.adb_path!r}. Set OPENCHRONICLE_ADB_PATH.",
+                args=cmd,
+            ) from exc
+        except subprocess.TimeoutExpired as exc:
+            raise ADBError(f"adb command timed out after {timeout:g}s", args=cmd) from exc
+
+        stderr = completed.stderr
+        if isinstance(stderr, bytes):
+            stderr = stderr.decode("utf-8", errors="replace")
+        result = ADBCommandResult(
+            args=cmd,
+            returncode=completed.returncode,
+            stdout=completed.stdout,
+            stderr=stderr or "",
+        )
+        if check and result.returncode != 0:
+            message = (result.stderr or result.stdout_text or "adb command failed").strip()
+            raise ADBError(
+                message,
+                args=cmd,
+                returncode=result.returncode,
+                stdout=result.stdout,
+                stderr=result.stderr,
+            )
+        return result

--- a/src/openchronicle/adb/memory.py
+++ b/src/openchronicle/adb/memory.py
@@ -1,0 +1,89 @@
+"""OpenChronicle memory adapter for ADB control events."""
+
+from __future__ import annotations
+
+import contextlib
+from dataclasses import dataclass, field
+from datetime import datetime
+from typing import Any
+
+from .. import paths
+from ..store import entries as entries_mod
+from ..store import files as files_mod
+from ..store import fts
+
+
+def _truncate(value: str, limit: int = 1200) -> str:
+    text = value.strip()
+    if len(text) <= limit:
+        return text
+    return text[:limit].rstrip() + "\n... [truncated]"
+
+
+def _event_daily_name(now: datetime) -> str:
+    return f"event-{now.strftime('%Y-%m-%d')}.md"
+
+
+def _ensure_event_file(conn, name: str, *, day: str) -> None:
+    if files_mod.memory_path(name).exists():
+        return
+    with contextlib.suppress(FileExistsError):
+        entries_mod.create_file(
+            conn,
+            name=name,
+            description=(
+                f"Activity log for {day}, including OpenChronicle sessions and "
+                "Android ADB agent operations."
+            ),
+            tags=["event", "session", "daily", "adb"],
+        )
+
+
+@dataclass
+class ADBMemoryRecorder:
+    """Append every ADB tool attempt to the daily OpenChronicle event file."""
+
+    preview_limit: int = 1200
+    default_tags: list[str] = field(default_factory=lambda: ["adb", "android"])
+
+    def record(
+        self,
+        *,
+        tool_name: str,
+        status: str,
+        device_id: str | None,
+        command: list[str],
+        summary: str,
+        params: dict[str, Any] | None = None,
+        output_preview: str = "",
+        artifact_path: str = "",
+        error: str = "",
+    ) -> str:
+        paths.ensure_dirs()
+        now = datetime.now().astimezone()
+        name = _event_daily_name(now)
+        command_text = " ".join(command)
+
+        body_parts = [
+            f"**ADB tool {tool_name}** ({now.strftime('%H:%M')})",
+            "",
+            f"- Status: {status}",
+            f"- Device: {device_id or 'auto'}",
+            f"- Command: `{command_text}`",
+            f"- Summary: {summary}",
+        ]
+        if artifact_path:
+            body_parts.append(f"- Artifact: `{artifact_path}`")
+        if params:
+            safe_params = {k: v for k, v in params.items() if v not in (None, "")}
+            if safe_params:
+                body_parts.append(f"- Params: `{safe_params}`")
+        if output_preview:
+            body_parts.extend(["", "Output preview:", "```text", _truncate(output_preview, self.preview_limit), "```"])
+        if error:
+            body_parts.extend(["", "Error:", "```text", _truncate(error, self.preview_limit), "```"])
+
+        tags = [*self.default_tags, f"tool:{tool_name}"]
+        with fts.cursor() as conn:
+            _ensure_event_file(conn, name, day=now.strftime("%Y-%m-%d"))
+            return entries_mod.append_entry(conn, name=name, content="\n".join(body_parts), tags=tags)

--- a/src/openchronicle/adb/safety.py
+++ b/src/openchronicle/adb/safety.py
@@ -1,0 +1,138 @@
+"""Safety policy for Android ADB commands.
+
+The ADB MCP server intentionally exposes only a small set of fixed tools, but
+this module is still called by the command runner so future helpers cannot
+accidentally bypass the same denylist.
+"""
+
+from __future__ import annotations
+
+import shlex
+from collections.abc import Sequence
+
+
+class ADBSafetyError(ValueError):
+    """Raised when an ADB command violates the local safety policy."""
+
+
+_BLOCKED_TOP_LEVEL = {
+    "disable-verity",
+    "enable-verity",
+    "reboot",
+    "remount",
+    "root",
+    "sideload",
+    "uninstall",
+    "unroot",
+}
+
+_BLOCKED_SHELL_COMMANDS = {
+    "reboot",
+    "rm",
+    "rmdir",
+    "su",
+    "wipe",
+}
+
+_BLOCKED_SEQUENCES = (
+    ("cmd", "package", "clear"),
+    ("cmd", "package", "uninstall"),
+    ("content", "delete"),
+    ("pm", "clear"),
+    ("pm", "uninstall"),
+    ("settings", "delete"),
+    ("settings", "put"),
+    ("settings", "reset"),
+)
+
+_BLOCKED_KEYEVENTS = {
+    "26",  # KEYCODE_POWER
+    "223",  # KEYCODE_SLEEP
+    "224",  # KEYCODE_WAKEUP
+    "keycode_power",
+    "keycode_sleep",
+    "keycode_wakeup",
+    "power",
+    "sleep",
+    "wakeup",
+}
+
+
+def _split_token(token: str) -> list[str]:
+    try:
+        return shlex.split(token)
+    except ValueError:
+        return [token]
+
+
+def _flatten(args: Sequence[str]) -> list[str]:
+    out: list[str] = []
+    for arg in args:
+        text = str(arg).strip()
+        if not text:
+            continue
+        out.extend(_split_token(text))
+    return [part.lower() for part in out if part]
+
+
+def _contains_sequence(tokens: Sequence[str], sequence: Sequence[str]) -> bool:
+    if not sequence or len(sequence) > len(tokens):
+        return False
+    last_start = len(tokens) - len(sequence)
+    return any(tuple(tokens[i : i + len(sequence)]) == tuple(sequence) for i in range(last_start + 1))
+
+
+def assert_safe(args: Sequence[str]) -> None:
+    """Reject destructive or privilege-escalating ADB commands.
+
+    Blocked categories:
+    - device reboot/root/remount/verity changes
+    - app uninstall or app data clearing
+    - shell deletion commands
+    - system settings mutation
+    - POWER/SLEEP/WAKEUP keyevents
+    """
+    tokens = _flatten(args)
+    if not tokens:
+        raise ADBSafetyError("empty adb command is not allowed")
+
+    for token in tokens:
+        if token in _BLOCKED_TOP_LEVEL:
+            raise ADBSafetyError(f"blocked high-risk adb command: {token}")
+
+    shell_tokens = tokens
+    if "shell" in tokens:
+        shell_tokens = tokens[tokens.index("shell") + 1 :]
+
+    for token in shell_tokens:
+        if token in _BLOCKED_SHELL_COMMANDS:
+            raise ADBSafetyError(f"blocked high-risk adb shell command: {token}")
+
+    for sequence in _BLOCKED_SEQUENCES:
+        if _contains_sequence(shell_tokens, sequence):
+            raise ADBSafetyError("blocked high-risk adb shell command: " + " ".join(sequence))
+
+    if _contains_sequence(shell_tokens, ("input", "keyevent")):
+        idx = shell_tokens.index("keyevent")
+        if idx + 1 < len(shell_tokens):
+            key = shell_tokens[idx + 1].removeprefix("keycode_")
+            original = shell_tokens[idx + 1]
+            if original in _BLOCKED_KEYEVENTS or key in _BLOCKED_KEYEVENTS:
+                raise ADBSafetyError(f"blocked high-risk keyevent: {shell_tokens[idx + 1]}")
+
+
+def validate_input_text(text: str) -> str:
+    """Return Android input-text syntax for safe text.
+
+    `adb shell input text` runs through the device shell. Reject shell
+    metacharacters instead of trying to quote arbitrary text across host and
+    device shells. Spaces are encoded as `%s`, which is Android's input syntax.
+    """
+    if text == "":
+        raise ADBSafetyError("adb_input_text requires non-empty text")
+    blocked = set("\r\n;&|<>`$(){}[]\\\"'")
+    bad = sorted({ch for ch in text if ch in blocked})
+    if bad:
+        shown = " ".join(repr(ch) for ch in bad)
+        raise ADBSafetyError(f"adb_input_text rejected shell metacharacter(s): {shown}")
+    return text.replace(" ", "%s")

--- a/src/openchronicle/adb/tools.py
+++ b/src/openchronicle/adb/tools.py
@@ -1,0 +1,554 @@
+"""High-level Android ADB operations exposed through MCP."""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass, field
+from datetime import datetime
+from pathlib import Path
+from typing import Any
+
+from .. import paths
+from . import safety
+from .client import ADBClient, ADBError
+from .memory import ADBMemoryRecorder
+
+_PACKAGE_RE = re.compile(r"^[A-Za-z][A-Za-z0-9_]*(?:\.[A-Za-z][A-Za-z0-9_]*)+$")
+_ACTIVITY_RE = re.compile(r"^[A-Za-z0-9_.$/]+$")
+_COMPONENT_RE = re.compile(r"(?P<package>[A-Za-z0-9_.$]+)/(?P<activity>[A-Za-z0-9_.$]+)")
+
+
+def _parse_devices(output: str) -> list[dict[str, Any]]:
+    devices: list[dict[str, Any]] = []
+    for raw_line in output.splitlines()[1:]:
+        line = raw_line.strip()
+        if not line:
+            continue
+        parts = line.split()
+        if len(parts) < 2:
+            continue
+        qualifiers: dict[str, str] = {}
+        for item in parts[2:]:
+            if ":" in item:
+                key, value = item.split(":", 1)
+                qualifiers[key] = value
+        devices.append(
+            {
+                "serial": parts[0],
+                "state": parts[1],
+                "qualifiers": qualifiers,
+                "raw": line,
+            }
+        )
+    return devices
+
+
+def _artifact_dir(name: str) -> Path:
+    path = paths.root() / "adb" / name
+    path.mkdir(parents=True, exist_ok=True)
+    return path
+
+
+def _require_non_negative_int(name: str, value: int) -> int:
+    integer = int(value)
+    if integer < 0:
+        raise safety.ADBSafetyError(f"{name} must be non-negative")
+    if integer > 10000:
+        raise safety.ADBSafetyError(f"{name} is implausibly large: {integer}")
+    return integer
+
+
+def _bounded_lines(lines: int) -> int:
+    value = int(lines)
+    if value < 1:
+        return 1
+    return min(value, 2000)
+
+
+def _command_with_redacted_tail(command: list[str]) -> list[str]:
+    if not command:
+        return command
+    return [*command[:-1], "<redacted>"]
+
+
+def _parse_component(text: str) -> dict[str, str]:
+    match = _COMPONENT_RE.search(text)
+    if not match:
+        return {"package": "", "activity": "", "raw": text.strip()}
+    return {
+        "package": match.group("package"),
+        "activity": match.group("activity"),
+        "raw": text.strip(),
+    }
+
+
+@dataclass
+class ADBController:
+    """ADB operation facade that always records into OpenChronicle memory."""
+
+    client: ADBClient = field(default_factory=ADBClient)
+    recorder: ADBMemoryRecorder = field(default_factory=ADBMemoryRecorder)
+
+    def _record_success(
+        self,
+        *,
+        tool_name: str,
+        device_id: str | None,
+        command: list[str],
+        summary: str,
+        params: dict[str, Any] | None = None,
+        output_preview: str = "",
+        artifact_path: str = "",
+    ) -> str:
+        return self.recorder.record(
+            tool_name=tool_name,
+            status="ok",
+            device_id=device_id,
+            command=command,
+            summary=summary,
+            params=params,
+            output_preview=output_preview,
+            artifact_path=artifact_path,
+        )
+
+    def _record_failure(
+        self,
+        *,
+        tool_name: str,
+        status: str,
+        device_id: str | None,
+        command: list[str],
+        summary: str,
+        params: dict[str, Any] | None = None,
+        error: str = "",
+    ) -> str:
+        return self.recorder.record(
+            tool_name=tool_name,
+            status=status,
+            device_id=device_id,
+            command=command,
+            summary=summary,
+            params=params,
+            error=error,
+        )
+
+    def _adb_error_payload(
+        self,
+        *,
+        tool_name: str,
+        device_id: str | None,
+        command: list[str],
+        params: dict[str, Any] | None,
+        exc: ADBError,
+    ) -> dict[str, Any]:
+        entry_id = self._record_failure(
+            tool_name=tool_name,
+            status="error",
+            device_id=device_id,
+            command=command,
+            summary=f"{tool_name} failed",
+            params=params,
+            error=str(exc),
+        )
+        return {
+            "ok": False,
+            "tool": tool_name,
+            "error": str(exc),
+            "returncode": exc.returncode,
+            "memory_entry_id": entry_id,
+        }
+
+    def _blocked_payload(
+        self,
+        *,
+        tool_name: str,
+        device_id: str | None,
+        command: list[str],
+        params: dict[str, Any] | None,
+        exc: safety.ADBSafetyError,
+    ) -> dict[str, Any]:
+        entry_id = self._record_failure(
+            tool_name=tool_name,
+            status="blocked",
+            device_id=device_id,
+            command=command,
+            summary=f"{tool_name} blocked by safety policy",
+            params=params,
+            error=str(exc),
+        )
+        return {
+            "ok": False,
+            "tool": tool_name,
+            "blocked": True,
+            "error": str(exc),
+            "memory_entry_id": entry_id,
+        }
+
+    def list_devices(self) -> dict[str, Any]:
+        tool = "adb_list_devices"
+        command = ["devices", "-l"]
+        try:
+            result = self.client.run(command, timeout=15)
+        except safety.ADBSafetyError as exc:
+            return self._blocked_payload(
+                tool_name=tool, device_id=None, command=command, params=None, exc=exc
+            )
+        except ADBError as exc:
+            return self._adb_error_payload(
+                tool_name=tool, device_id=None, command=command, params=None, exc=exc
+            )
+        devices = _parse_devices(result.stdout_text)
+        entry_id = self._record_success(
+            tool_name=tool,
+            device_id=None,
+            command=self.client.command_for_display(command),
+            summary=f"Listed {len(devices)} Android device(s).",
+            output_preview=result.stdout_text,
+        )
+        return {"ok": True, "tool": tool, "count": len(devices), "devices": devices, "memory_entry_id": entry_id}
+
+    def screenshot(self, device_id: str | None = None) -> dict[str, Any]:
+        tool = "adb_screenshot"
+        command = ["exec-out", "screencap", "-p"]
+        params = {"device_id": device_id}
+        display = self.client.command_for_display(command, device_id)
+        try:
+            result = self.client.run(command, device_id=device_id, timeout=20, binary=True)
+        except safety.ADBSafetyError as exc:
+            return self._blocked_payload(
+                tool_name=tool, device_id=device_id, command=display, params=params, exc=exc
+            )
+        except ADBError as exc:
+            return self._adb_error_payload(
+                tool_name=tool, device_id=device_id, command=display, params=params, exc=exc
+            )
+
+        now = datetime.now().astimezone()
+        out_path = _artifact_dir("screenshots") / f"{now.strftime('%Y%m%d-%H%M%S-%f')}.png"
+        out_path.write_bytes(result.stdout_bytes)
+        entry_id = self._record_success(
+            tool_name=tool,
+            device_id=device_id,
+            command=display,
+            summary=f"Captured Android screenshot ({len(result.stdout_bytes)} bytes).",
+            params=params,
+            artifact_path=str(out_path),
+        )
+        return {
+            "ok": True,
+            "tool": tool,
+            "path": str(out_path),
+            "bytes": len(result.stdout_bytes),
+            "memory_entry_id": entry_id,
+        }
+
+    def dump_ui(self, device_id: str | None = None) -> dict[str, Any]:
+        tool = "adb_dump_ui"
+        dump_path = "/sdcard/window.xml"
+        command = ["shell", "uiautomator", "dump", dump_path]
+        cat_command = ["exec-out", "cat", dump_path]
+        params = {"device_id": device_id}
+        display = self.client.command_for_display(command, device_id)
+        try:
+            dump_result = self.client.run(command, device_id=device_id, timeout=20)
+            xml_result = self.client.run(cat_command, device_id=device_id, timeout=20)
+        except safety.ADBSafetyError as exc:
+            return self._blocked_payload(
+                tool_name=tool, device_id=device_id, command=display, params=params, exc=exc
+            )
+        except ADBError as exc:
+            return self._adb_error_payload(
+                tool_name=tool, device_id=device_id, command=display, params=params, exc=exc
+            )
+        xml = xml_result.stdout_text.strip()
+        preview = dump_result.stdout_text + "\n" + xml[:1000]
+        entry_id = self._record_success(
+            tool_name=tool,
+            device_id=device_id,
+            command=display,
+            summary=f"Dumped Android UI XML ({len(xml)} characters).",
+            params=params,
+            output_preview=preview,
+        )
+        return {"ok": True, "tool": tool, "xml": xml, "memory_entry_id": entry_id}
+
+    def tap(self, x: int, y: int, device_id: str | None = None) -> dict[str, Any]:
+        tool = "adb_tap"
+        params = {"x": x, "y": y, "device_id": device_id}
+        try:
+            sx = _require_non_negative_int("x", x)
+            sy = _require_non_negative_int("y", y)
+            command = ["shell", "input", "tap", str(sx), str(sy)]
+            display = self.client.command_for_display(command, device_id)
+            result = self.client.run(command, device_id=device_id, timeout=10)
+        except safety.ADBSafetyError as exc:
+            command = ["shell", "input", "tap", str(x), str(y)]
+            display = self.client.command_for_display(command, device_id)
+            return self._blocked_payload(
+                tool_name=tool, device_id=device_id, command=display, params=params, exc=exc
+            )
+        except ADBError as exc:
+            return self._adb_error_payload(
+                tool_name=tool, device_id=device_id, command=display, params=params, exc=exc
+            )
+        entry_id = self._record_success(
+            tool_name=tool,
+            device_id=device_id,
+            command=display,
+            summary=f"Tapped Android screen at ({sx}, {sy}).",
+            params=params,
+            output_preview=result.stdout_text,
+        )
+        return {"ok": True, "tool": tool, "x": sx, "y": sy, "memory_entry_id": entry_id}
+
+    def swipe(
+        self,
+        x1: int,
+        y1: int,
+        x2: int,
+        y2: int,
+        duration_ms: int = 300,
+        device_id: str | None = None,
+    ) -> dict[str, Any]:
+        tool = "adb_swipe"
+        params = {
+            "x1": x1,
+            "y1": y1,
+            "x2": x2,
+            "y2": y2,
+            "duration_ms": duration_ms,
+            "device_id": device_id,
+        }
+        try:
+            sx1 = _require_non_negative_int("x1", x1)
+            sy1 = _require_non_negative_int("y1", y1)
+            sx2 = _require_non_negative_int("x2", x2)
+            sy2 = _require_non_negative_int("y2", y2)
+            duration = min(max(int(duration_ms), 0), 60000)
+            command = [
+                "shell",
+                "input",
+                "swipe",
+                str(sx1),
+                str(sy1),
+                str(sx2),
+                str(sy2),
+                str(duration),
+            ]
+            display = self.client.command_for_display(command, device_id)
+            result = self.client.run(command, device_id=device_id, timeout=15)
+        except safety.ADBSafetyError as exc:
+            command = ["shell", "input", "swipe", str(x1), str(y1), str(x2), str(y2), str(duration_ms)]
+            display = self.client.command_for_display(command, device_id)
+            return self._blocked_payload(
+                tool_name=tool, device_id=device_id, command=display, params=params, exc=exc
+            )
+        except ADBError as exc:
+            return self._adb_error_payload(
+                tool_name=tool, device_id=device_id, command=display, params=params, exc=exc
+            )
+        entry_id = self._record_success(
+            tool_name=tool,
+            device_id=device_id,
+            command=display,
+            summary=f"Swiped Android screen from ({sx1}, {sy1}) to ({sx2}, {sy2}).",
+            params=params,
+            output_preview=result.stdout_text,
+        )
+        return {
+            "ok": True,
+            "tool": tool,
+            "x1": sx1,
+            "y1": sy1,
+            "x2": sx2,
+            "y2": sy2,
+            "duration_ms": duration,
+            "memory_entry_id": entry_id,
+        }
+
+    def input_text(self, text: str, device_id: str | None = None) -> dict[str, Any]:
+        tool = "adb_input_text"
+        params = {"text_length": len(text), "device_id": device_id}
+        try:
+            encoded = safety.validate_input_text(text)
+            command = ["shell", "input", "text", encoded]
+            display = self.client.command_for_display(_command_with_redacted_tail(command), device_id)
+            result = self.client.run(command, device_id=device_id, timeout=10)
+        except safety.ADBSafetyError as exc:
+            command = ["shell", "input", "text", "<redacted>"]
+            display = self.client.command_for_display(command, device_id)
+            return self._blocked_payload(
+                tool_name=tool, device_id=device_id, command=display, params=params, exc=exc
+            )
+        except ADBError as exc:
+            return self._adb_error_payload(
+                tool_name=tool, device_id=device_id, command=display, params=params, exc=exc
+            )
+        entry_id = self._record_success(
+            tool_name=tool,
+            device_id=device_id,
+            command=display,
+            summary=f"Entered {len(text)} character(s) of text on Android device.",
+            params=params,
+            output_preview=result.stdout_text,
+        )
+        return {"ok": True, "tool": tool, "text_length": len(text), "memory_entry_id": entry_id}
+
+    def keyevent(self, keyevent: str | int, device_id: str | None = None) -> dict[str, Any]:
+        tool = "adb_keyevent"
+        key = str(keyevent).strip()
+        params = {"keyevent": key, "device_id": device_id}
+        command = ["shell", "input", "keyevent", key]
+        display = self.client.command_for_display(command, device_id)
+        try:
+            if not key:
+                raise safety.ADBSafetyError("keyevent is required")
+            result = self.client.run(command, device_id=device_id, timeout=10)
+        except safety.ADBSafetyError as exc:
+            return self._blocked_payload(
+                tool_name=tool, device_id=device_id, command=display, params=params, exc=exc
+            )
+        except ADBError as exc:
+            return self._adb_error_payload(
+                tool_name=tool, device_id=device_id, command=display, params=params, exc=exc
+            )
+        entry_id = self._record_success(
+            tool_name=tool,
+            device_id=device_id,
+            command=display,
+            summary=f"Sent Android keyevent {key}.",
+            params=params,
+            output_preview=result.stdout_text,
+        )
+        return {"ok": True, "tool": tool, "keyevent": key, "memory_entry_id": entry_id}
+
+    def current_app(self, device_id: str | None = None) -> dict[str, Any]:
+        tool = "adb_current_app"
+        command = ["shell", "dumpsys", "window"]
+        params = {"device_id": device_id}
+        display = self.client.command_for_display(command, device_id)
+        try:
+            result = self.client.run(command, device_id=device_id, timeout=20)
+        except safety.ADBSafetyError as exc:
+            return self._blocked_payload(
+                tool_name=tool, device_id=device_id, command=display, params=params, exc=exc
+            )
+        except ADBError as exc:
+            return self._adb_error_payload(
+                tool_name=tool, device_id=device_id, command=display, params=params, exc=exc
+            )
+
+        raw_line = ""
+        for line in result.stdout_text.splitlines():
+            if "mCurrentFocus" in line or "mFocusedApp" in line:
+                raw_line = line.strip()
+                break
+        parsed = _parse_component(raw_line)
+        entry_id = self._record_success(
+            tool_name=tool,
+            device_id=device_id,
+            command=display,
+            summary=f"Read current Android app: {parsed.get('package') or 'unknown'}.",
+            params=params,
+            output_preview=raw_line,
+        )
+        return {"ok": True, "tool": tool, **parsed, "memory_entry_id": entry_id}
+
+    def open_app(
+        self,
+        package_name: str,
+        activity: str | None = None,
+        device_id: str | None = None,
+    ) -> dict[str, Any]:
+        tool = "adb_open_app"
+        params = {"package_name": package_name, "activity": activity, "device_id": device_id}
+        try:
+            if not _PACKAGE_RE.match(package_name):
+                raise safety.ADBSafetyError(f"invalid Android package name: {package_name!r}")
+            if activity:
+                if not _ACTIVITY_RE.match(activity):
+                    raise safety.ADBSafetyError(f"invalid Android activity name: {activity!r}")
+                component = activity if "/" in activity else f"{package_name}/{activity}"
+                command = ["shell", "am", "start", "-n", component]
+            else:
+                command = [
+                    "shell",
+                    "monkey",
+                    "-p",
+                    package_name,
+                    "-c",
+                    "android.intent.category.LAUNCHER",
+                    "1",
+                ]
+            display = self.client.command_for_display(command, device_id)
+            result = self.client.run(command, device_id=device_id, timeout=20)
+        except safety.ADBSafetyError as exc:
+            command = ["shell", "monkey", "-p", package_name, "-c", "android.intent.category.LAUNCHER", "1"]
+            display = self.client.command_for_display(command, device_id)
+            return self._blocked_payload(
+                tool_name=tool, device_id=device_id, command=display, params=params, exc=exc
+            )
+        except ADBError as exc:
+            return self._adb_error_payload(
+                tool_name=tool, device_id=device_id, command=display, params=params, exc=exc
+            )
+        entry_id = self._record_success(
+            tool_name=tool,
+            device_id=device_id,
+            command=display,
+            summary=f"Opened Android app {package_name}.",
+            params=params,
+            output_preview=result.stdout_text,
+        )
+        return {
+            "ok": True,
+            "tool": tool,
+            "package_name": package_name,
+            "activity": activity or "",
+            "memory_entry_id": entry_id,
+        }
+
+    def read_logcat(
+        self,
+        lines: int = 200,
+        filter_expr: str | None = None,
+        device_id: str | None = None,
+    ) -> dict[str, Any]:
+        tool = "adb_read_logcat"
+        line_count = _bounded_lines(lines)
+        params = {"lines": line_count, "filter_expr": filter_expr, "device_id": device_id}
+        command = ["logcat", "-d", "-t", str(line_count)]
+        if filter_expr:
+            if not re.match(r"^[A-Za-z0-9_.*:\-\s]+$", filter_expr):
+                exc = safety.ADBSafetyError("filter_expr contains unsupported characters")
+                display = self.client.command_for_display(command, device_id)
+                return self._blocked_payload(
+                    tool_name=tool, device_id=device_id, command=display, params=params, exc=exc
+                )
+            command.extend(filter_expr.split())
+        display = self.client.command_for_display(command, device_id)
+        try:
+            result = self.client.run(command, device_id=device_id, timeout=30)
+        except safety.ADBSafetyError as exc:
+            return self._blocked_payload(
+                tool_name=tool, device_id=device_id, command=display, params=params, exc=exc
+            )
+        except ADBError as exc:
+            return self._adb_error_payload(
+                tool_name=tool, device_id=device_id, command=display, params=params, exc=exc
+            )
+        entry_id = self._record_success(
+            tool_name=tool,
+            device_id=device_id,
+            command=display,
+            summary=f"Read last {line_count} Android logcat line(s).",
+            params=params,
+            output_preview=result.stdout_text,
+        )
+        return {
+            "ok": True,
+            "tool": tool,
+            "lines": line_count,
+            "logcat": result.stdout_text,
+            "memory_entry_id": entry_id,
+        }

--- a/src/openchronicle/mcp/adb_server.py
+++ b/src/openchronicle/mcp/adb_server.py
@@ -1,0 +1,124 @@
+"""MCP server exposing safe Android ADB control tools."""
+
+from __future__ import annotations
+
+import json
+
+from ..adb import ADBController
+from ..config import Config
+
+_SERVER_INSTRUCTIONS = """\
+# OpenChronicle ADB Control
+
+This MCP server lets an agent operate an Android device through a small, safe
+ADB tool surface. Every tool call is appended to OpenChronicle's daily
+event-YYYY-MM-DD.md memory file.
+
+Rules for agents:
+
+1. Observe before acting: call adb_screenshot or adb_dump_ui before tap/swipe/text.
+2. Do not request delete, uninstall, clear-data, root, reboot, remount, or settings writes.
+3. Stop and ask the user before payments, passwords, SMS codes, private data export, or account changes.
+4. Prefer package/activity based app launch over blind navigation when the package is known.
+"""
+
+
+def build_server(cfg: Config | None = None, controller: ADBController | None = None):
+    """Construct and return a FastMCP server instance for ADB control."""
+    from mcp.server.fastmcp import FastMCP
+
+    del cfg  # The ADB server is stdio-first and currently has no config section.
+    adb = controller or ADBController()
+    server = FastMCP("openchronicle-adb", instructions=_SERVER_INSTRUCTIONS)
+
+    @server.tool()
+    def adb_list_devices() -> str:
+        """List Android devices visible to adb and record the operation in memory."""
+        return json.dumps(adb.list_devices(), ensure_ascii=False)
+
+    @server.tool()
+    def adb_screenshot(device_id: str | None = None) -> str:
+        """Capture a PNG screenshot from the Android device and return its local path."""
+        return json.dumps(adb.screenshot(device_id=device_id), ensure_ascii=False)
+
+    @server.tool()
+    def adb_dump_ui(device_id: str | None = None) -> str:
+        """Dump the Android UI Automator XML tree for the current screen."""
+        return json.dumps(adb.dump_ui(device_id=device_id), ensure_ascii=False)
+
+    @server.tool()
+    def adb_tap(x: int, y: int, device_id: str | None = None) -> str:
+        """Tap an Android screen coordinate."""
+        return json.dumps(adb.tap(x=x, y=y, device_id=device_id), ensure_ascii=False)
+
+    @server.tool()
+    def adb_swipe(
+        x1: int,
+        y1: int,
+        x2: int,
+        y2: int,
+        duration_ms: int = 300,
+        device_id: str | None = None,
+    ) -> str:
+        """Swipe from one Android screen coordinate to another."""
+        return json.dumps(
+            adb.swipe(
+                x1=x1,
+                y1=y1,
+                x2=x2,
+                y2=y2,
+                duration_ms=duration_ms,
+                device_id=device_id,
+            ),
+            ensure_ascii=False,
+        )
+
+    @server.tool()
+    def adb_input_text(text: str, device_id: str | None = None) -> str:
+        """Input text through Android's input command. Text is redacted in memory."""
+        return json.dumps(adb.input_text(text=text, device_id=device_id), ensure_ascii=False)
+
+    @server.tool()
+    def adb_keyevent(keyevent: str, device_id: str | None = None) -> str:
+        """Send a safe Android keyevent, such as BACK, HOME, ENTER, or a numeric keycode."""
+        return json.dumps(adb.keyevent(keyevent=keyevent, device_id=device_id), ensure_ascii=False)
+
+    @server.tool()
+    def adb_current_app(device_id: str | None = None) -> str:
+        """Return the foreground Android package/activity when adb can determine it."""
+        return json.dumps(adb.current_app(device_id=device_id), ensure_ascii=False)
+
+    @server.tool()
+    def adb_open_app(
+        package_name: str,
+        activity: str | None = None,
+        device_id: str | None = None,
+    ) -> str:
+        """Open an Android app by package name, optionally with an explicit activity."""
+        return json.dumps(
+            adb.open_app(package_name=package_name, activity=activity, device_id=device_id),
+            ensure_ascii=False,
+        )
+
+    @server.tool()
+    def adb_read_logcat(
+        lines: int = 200,
+        filter_expr: str | None = None,
+        device_id: str | None = None,
+    ) -> str:
+        """Read bounded logcat output. Defaults to the last 200 lines."""
+        return json.dumps(
+            adb.read_logcat(lines=lines, filter_expr=filter_expr, device_id=device_id),
+            ensure_ascii=False,
+        )
+
+    return server
+
+
+def run_stdio() -> None:
+    """Run the ADB MCP server on stdio."""
+    build_server().run()
+
+
+if __name__ == "__main__":
+    run_stdio()

--- a/tests/test_adb_control.py
+++ b/tests/test_adb_control.py
@@ -1,0 +1,114 @@
+from __future__ import annotations
+
+import pytest
+
+from openchronicle.adb.client import ADBCommandResult
+from openchronicle.adb.memory import ADBMemoryRecorder
+from openchronicle.adb.safety import ADBSafetyError, assert_safe
+from openchronicle.adb.tools import ADBController, _parse_devices
+from openchronicle.mcp import adb_server
+from openchronicle.store import files as files_mod
+
+
+class FakeADBClient:
+    adb_path = "adb"
+
+    def __init__(self, stdout: str = "", stdout_bytes: bytes = b"") -> None:
+        self.stdout = stdout
+        self.stdout_bytes = stdout_bytes
+        self.calls: list[tuple[list[str], str | None, bool]] = []
+
+    def command_for_display(self, args, device_id=None):
+        command = [self.adb_path]
+        if device_id:
+            command.extend(["-s", device_id])
+        command.extend(str(a) for a in args)
+        return command
+
+    def run(self, args, *, device_id=None, timeout=30.0, binary=False, check=True):
+        del timeout, check
+        self.calls.append((list(args), device_id, binary))
+        stdout = self.stdout_bytes if binary else self.stdout
+        return ADBCommandResult(
+            args=self.command_for_display(args, device_id),
+            returncode=0,
+            stdout=stdout,
+            stderr="",
+        )
+
+
+def test_safety_blocks_destructive_commands() -> None:
+    blocked = [
+        ["uninstall", "com.example.app"],
+        ["reboot"],
+        ["root"],
+        ["shell", "pm", "clear", "com.example.app"],
+        ["shell", "settings", "put", "system", "screen_brightness", "1"],
+        ["shell", "rm", "-rf", "/sdcard/Download"],
+        ["shell", "input", "keyevent", "POWER"],
+        ["shell", "input", "keyevent", "26"],
+    ]
+    for command in blocked:
+        with pytest.raises(ADBSafetyError):
+            assert_safe(command)
+
+
+def test_safety_allows_mvp_commands() -> None:
+    allowed = [
+        ["devices", "-l"],
+        ["exec-out", "screencap", "-p"],
+        ["shell", "uiautomator", "dump", "/sdcard/window.xml"],
+        ["shell", "input", "tap", "100", "200"],
+        ["shell", "input", "swipe", "100", "900", "100", "100", "300"],
+        ["shell", "input", "keyevent", "BACK"],
+        ["shell", "monkey", "-p", "com.example.app", "-c", "android.intent.category.LAUNCHER", "1"],
+    ]
+    for command in allowed:
+        assert_safe(command)
+
+
+def test_parse_devices() -> None:
+    output = """List of devices attached
+emulator-5554 device product:sdk_gphone_x86_64 model:sdk_gphone64 transport_id:1
+R58M123 offline usb:1-1
+"""
+    devices = _parse_devices(output)
+    assert devices[0]["serial"] == "emulator-5554"
+    assert devices[0]["state"] == "device"
+    assert devices[0]["qualifiers"]["product"] == "sdk_gphone_x86_64"
+    assert devices[1]["state"] == "offline"
+
+
+def test_list_devices_writes_openchronicle_event(ac_root) -> None:
+    client = FakeADBClient(
+        stdout="List of devices attached\nemulator-5554 device product:sdk model:Pixel\n"
+    )
+    controller = ADBController(client=client, recorder=ADBMemoryRecorder())
+
+    result = controller.list_devices()
+
+    assert result["ok"] is True
+    assert result["count"] == 1
+    event_files = list((ac_root / "memory").glob("event-*.md"))
+    assert len(event_files) == 1
+    parsed = files_mod.read_file(event_files[0])
+    assert parsed.entries
+    assert "ADB tool adb_list_devices" in parsed.entries[-1].body
+
+
+def test_blocked_input_text_is_recorded(ac_root) -> None:
+    controller = ADBController(client=FakeADBClient(), recorder=ADBMemoryRecorder())
+
+    result = controller.input_text("hello; rm -rf /")
+
+    assert result["ok"] is False
+    assert result["blocked"] is True
+    assert not controller.client.calls
+    event_file = next((ac_root / "memory").glob("event-*.md"))
+    parsed = files_mod.read_file(event_file)
+    assert "blocked by safety policy" in parsed.entries[-1].body
+
+
+def test_adb_mcp_server_builds() -> None:
+    server = adb_server.build_server(controller=ADBController(client=FakeADBClient()))
+    assert server is not None


### PR DESCRIPTION

  ## Summary

  Adds a separate Android ADB Control MCP server for OpenChronicle.

  - Adds `openchronicle adb-mcp` stdio MCP server.
  - Exposes ADB tools for device listing, screenshot, UI dump, tap, swipe, text input, keyevent,
  current app, app launch, and logcat.
  - Writes every ADB tool attempt into OpenChronicle daily event memory.
  - Adds `safety.py` denylist for destructive or privileged ADB commands.
  - Adds Windows 11 + WSL2 setup docs in `README_ADB_AGENT.md`.

  - `adb_input_text`
  - `adb_keyevent`
  - `adb_current_app`
  - `adb_open_app`
  - `adb_read_logcat`

  ## Validation

  - `uv run pytest --basetemp .pytest_cache\full-test-tmp-2`
  - `uv run python -m compileall src\openchronicle\adb src\openchronicle\mcp\adb_server.py`
  - `E:\ai\product\.tooling\platform-tools\adb.exe devices -l`
  - MCP stdio smoke test: `list_tools` + `adb_list_devices` successful

  Result: `105 passed, 1 skipped`.