### PR TITLE
fix(session): recover orphan active sessions on daemon startup

### DIFF
--- a/src/openchronicle/daemon.py
+++ b/src/openchronicle/daemon.py
@@ -17,6 +17,7 @@ from . import paths
 from .capture import scheduler as capture_scheduler
 from .config import Config
 from .logger import get
+from .session import recovery as session_recovery
 from .session import tick as session_tick
 from .timeline import tick as timeline_tick
 
@@ -51,6 +52,20 @@ async def _mcp_loop(cfg: Config) -> None:
 async def _run(cfg: Config, *, capture_only: bool = False) -> None:
     paths.ensure_dirs()
     paths.pid_file().write_text(str(os.getpid()))
+
+    # Force-end any sessions left in 'active' state by a previous hard
+    # crash (SIGKILL / OOM / power loss). Without this, the daily
+    # safety-net's reduce_all_pending excludes 'active' rows and the
+    # crashed session's work is lost forever. Runs before SessionManager
+    # so any new events from this boot can't race the recovery.
+    try:
+        recovered = session_recovery.recover_orphan_sessions(cfg)
+        if recovered:
+            logger.info("recovered %d orphan session(s) from previous run", recovered)
+    except Exception as exc:  # noqa: BLE001
+        # Recovery failure must not block the daemon — better to have a
+        # running daemon with one un-recovered orphan than no daemon.
+        logger.error("orphan-session recovery failed: %s", exc, exc_info=True)
 
     # SessionManager observes every capture-worthy event and fires the
     # reducer via its on_session_end callback. Built even when

--- a/src/openchronicle/session/recovery.py
+++ b/src/openchronicle/session/recovery.py
@@ -92,4 +92,10 @@ def _infer_end_time(
         # cuts are aligned, but be defensive).
         return min(block_end, upper_bound)
 
-    return start_time + _EMPTY_SESSION_FALLBACK
+    # Clamp the fallback to upper_bound for the same disjoint-sessions
+    # invariant: if the next session begins within a minute of this
+    # orphan's start (back-to-back hard crashes), an unclamped 1-min
+    # fallback would push our end_time past the next session's start
+    # and the eventual reducer pass over [start, end) would sweep up
+    # blocks that belong to the next session, double-attributing them.
+    return min(start_time + _EMPTY_SESSION_FALLBACK, upper_bound)

--- a/src/openchronicle/session/recovery.py
+++ b/src/openchronicle/session/recovery.py
@@ -1,0 +1,95 @@
+"""Recover sessions left in 'active' state by a previous hard crash.
+
+The graceful shutdown path in ``daemon._run`` calls
+``SessionManager.force_end`` so any in-progress session is persisted as
+``ended`` before the process exits. A SIGKILL / OOM kill / kernel panic
+/ power loss skips that — the ``sessions`` row stays at
+``status='active'`` with ``end_time=NULL``, and the daily safety-net's
+``reduce_all_pending`` query explicitly excludes ``active`` rows
+(`session/store.py:list_pending_reduction`). The session's work is then
+silently lost: never reduced, never classified, no ``event-*.md`` entry.
+
+This module runs once at daemon startup, before the new
+``SessionManager`` takes over. It lists every ``active`` row, infers a
+plausible ``end_time`` from the timeline blocks the previous run did
+manage to persist, and force-ends each row so the existing safety-net
+catch-up picks them up on its next pass.
+
+The inferred end_time is the latest ``timeline_blocks.end_time`` whose
+``start_time`` falls within the orphan's plausible lifetime — bounded
+above by either the next session row's ``start_time`` (so consecutive
+orphans don't pollute each other) or the configured
+``session.max_session_hours``, whichever is sooner. If no blocks were
+ever persisted (the crash beat the 1-min aggregator), the orphan ends
+``start_time + 1 minute`` so the reducer's empty-window code path runs
+and marks it ``reduced`` as a no-op rather than leaving it stuck.
+"""
+
+from __future__ import annotations
+
+import sqlite3
+from datetime import datetime, timedelta
+
+from ..config import Config
+from ..logger import get
+from ..store import fts
+from ..timeline import store as timeline_store
+from . import store as session_store
+
+logger = get("openchronicle.session.recovery")
+
+# How long after start_time we treat as the latest plausible end for an
+# orphan that has *no* persisted timeline blocks. One minute is enough
+# for the reducer to recognize the window as empty (its block-count
+# branch handles this case explicitly) and mark the row 'reduced' as a
+# no-op, freeing it from the orphan state forever.
+_EMPTY_SESSION_FALLBACK = timedelta(minutes=1)
+
+
+def recover_orphan_sessions(cfg: Config) -> int:
+    """Force-end any ``active`` sessions left behind by a hard crash.
+
+    Returns the count of orphans that were force-ended. Idempotent: a
+    second call sees no ``active`` rows and is a no-op.
+    """
+    with fts.cursor() as conn:
+        active = session_store.list_active(conn)
+        if not active:
+            return 0
+        max_window = timedelta(hours=cfg.session.max_session_hours)
+        for row in active:
+            end_time = _infer_end_time(conn, row.start_time, max_window)
+            session_store.mark_ended(conn, row.id, end_time)
+            logger.info(
+                "recovered orphan session %s: start=%s, inferred end=%s",
+                row.id,
+                row.start_time.isoformat(),
+                end_time.isoformat(),
+            )
+    return len(active)
+
+
+def _infer_end_time(
+    conn: sqlite3.Connection, start_time: datetime, max_window: timedelta
+) -> datetime:
+    """Best-guess end_time for an orphan: latest block end inside its window.
+
+    The window is ``[start_time, upper_bound)`` where ``upper_bound`` is
+    the next session's start (so two orphans don't claim each other's
+    blocks) capped by ``start_time + max_session_hours`` (the absolute
+    physical session ceiling enforced by SessionManager).
+    """
+    next_start = session_store.next_session_start_after(conn, start_time)
+    ceiling = start_time + max_window
+    upper_bound = (
+        next_start if next_start is not None and next_start < ceiling else ceiling
+    )
+
+    block_end = timeline_store.latest_end_in_window(conn, start_time, upper_bound)
+    if block_end is not None and block_end > start_time:
+        # Don't extend past the next session's start even if a block's
+        # end_time would (shouldn't happen if the aggregator and session
+        # cuts are aligned, but be defensive).
+        return min(block_end, upper_bound)
+
+    return start_time + _EMPTY_SESSION_FALLBACK

--- a/src/openchronicle/session/store.py
+++ b/src/openchronicle/session/store.py
@@ -177,6 +177,27 @@ def list_active(conn: sqlite3.Connection) -> list[SessionRow]:
     return [_to_row(r) for r in rows]
 
 
+def next_session_start_after(
+    conn: sqlite3.Connection, start_time: datetime
+) -> datetime | None:
+    """Earliest ``start_time`` of any session that began after ``start_time``.
+
+    Used by the orphan recovery path to bound an orphan's inferred
+    end_time: blocks past the *next* session's start can't belong to
+    this one, regardless of the orphan's max_session_hours window.
+    """
+    row = conn.execute(
+        "SELECT MIN(start_time) FROM sessions WHERE start_time > ?",
+        (start_time.isoformat(),),
+    ).fetchone()
+    if not row or not row[0]:
+        return None
+    try:
+        return datetime.fromisoformat(row[0])
+    except (TypeError, ValueError):
+        return None
+
+
 def list_due_for_retry(conn: sqlite3.Connection, *, now: datetime) -> list[SessionRow]:
     rows = conn.execute(
         """

--- a/src/openchronicle/timeline/store.py
+++ b/src/openchronicle/timeline/store.py
@@ -99,6 +99,34 @@ def get_latest_end(conn: sqlite3.Connection) -> datetime | None:
         return None
 
 
+def latest_end_in_window(
+    conn: sqlite3.Connection, start: datetime, end: datetime
+) -> datetime | None:
+    """Latest ``end_time`` of any block whose ``start_time`` falls in ``[start, end)``.
+
+    Used by the orphan-session recovery path: an active session left
+    behind by a hard crash needs an inferred end_time, and the freshest
+    persisted block within the session's plausible lifetime is the best
+    available estimate.
+    """
+    row = conn.execute(
+        """
+        SELECT end_time FROM timeline_blocks
+         WHERE start_time >= ?
+           AND start_time <  ?
+         ORDER BY end_time DESC
+         LIMIT 1
+        """,
+        (start.isoformat(), end.isoformat()),
+    ).fetchone()
+    if not row:
+        return None
+    try:
+        return datetime.fromisoformat(row[0])
+    except (TypeError, ValueError):
+        return None
+
+
 def query_recent(conn: sqlite3.Connection, *, limit: int = 12) -> list[TimelineBlock]:
     """Most recent blocks, oldest first in the returned list."""
     rows = conn.execute(

--- a/tests/test_session_recovery.py
+++ b/tests/test_session_recovery.py
@@ -1,0 +1,179 @@
+"""Tests for the orphan-active-session recovery path on daemon startup."""
+
+from __future__ import annotations
+
+from datetime import datetime, timedelta
+from pathlib import Path
+
+from openchronicle import config as config_mod
+from openchronicle.session import recovery
+from openchronicle.session import store as session_store
+from openchronicle.store import fts
+from openchronicle.timeline import store as timeline_store
+
+
+def _ts(s: str) -> datetime:
+    """Parse a wall-clock-with-tz ISO string to a tz-aware datetime."""
+    return datetime.fromisoformat(s)
+
+
+def _insert_active(conn, *, session_id: str, start: str) -> None:
+    session_store.insert(
+        conn,
+        session_store.SessionRow(
+            id=session_id, start_time=_ts(start), status="active",
+        ),
+    )
+
+
+def _insert_block(conn, *, start: str, end: str) -> None:
+    timeline_store.insert(
+        conn,
+        timeline_store.TimelineBlock(
+            start_time=_ts(start),
+            end_time=_ts(end),
+            entries=["[Cursor] worked on something"],
+            apps_used=["Cursor"],
+            capture_count=3,
+        ),
+    )
+
+
+def _cfg(ac_root: Path) -> config_mod.Config:
+    return config_mod.load(ac_root / "config.toml")
+
+
+def test_recover_no_orphans_is_noop(ac_root: Path) -> None:
+    """Empty DB → returns 0, no errors."""
+    cfg = _cfg(ac_root)
+    assert recovery.recover_orphan_sessions(cfg) == 0
+
+
+def test_recover_orphan_with_blocks_uses_latest_block_end(ac_root: Path) -> None:
+    """An orphan with persisted timeline blocks ends at the latest block end."""
+    cfg = _cfg(ac_root)
+    with fts.cursor() as conn:
+        _insert_active(conn, session_id="sess_a", start="2026-04-26T09:00:00+08:00")
+        _insert_block(conn, start="2026-04-26T09:00:00+08:00", end="2026-04-26T09:01:00+08:00")
+        _insert_block(conn, start="2026-04-26T09:01:00+08:00", end="2026-04-26T09:02:00+08:00")
+        _insert_block(conn, start="2026-04-26T09:25:00+08:00", end="2026-04-26T09:26:00+08:00")
+
+    assert recovery.recover_orphan_sessions(cfg) == 1
+
+    with fts.cursor() as conn:
+        row = session_store.get_by_id(conn, "sess_a")
+        assert row is not None
+        assert row.status == "ended"
+        assert row.end_time == _ts("2026-04-26T09:26:00+08:00")
+
+
+def test_recover_orphan_with_no_blocks_uses_one_minute_fallback(ac_root: Path) -> None:
+    """Crash before any block was aggregated → end_time = start + 1min."""
+    cfg = _cfg(ac_root)
+    start = "2026-04-26T09:00:00+08:00"
+    with fts.cursor() as conn:
+        _insert_active(conn, session_id="sess_b", start=start)
+
+    assert recovery.recover_orphan_sessions(cfg) == 1
+
+    with fts.cursor() as conn:
+        row = session_store.get_by_id(conn, "sess_b")
+        assert row is not None
+        assert row.status == "ended"
+        assert row.end_time == _ts(start) + timedelta(minutes=1)
+
+
+def test_recover_two_orphans_dont_pollute_each_other(ac_root: Path) -> None:
+    """Two consecutive orphans: A's blocks must not extend into B's window.
+
+    Without ``next_session_start_after`` the latest-block-in-window query
+    for A would walk all the way up to A.start + max_session_hours and
+    swallow B's blocks too, ending A at B's last activity instead of
+    A's last activity.
+    """
+    cfg = _cfg(ac_root)
+    with fts.cursor() as conn:
+        _insert_active(conn, session_id="sess_a", start="2026-04-26T09:00:00+08:00")
+        _insert_active(conn, session_id="sess_b", start="2026-04-26T09:35:00+08:00")
+        # Blocks attributable to A
+        _insert_block(conn, start="2026-04-26T09:00:00+08:00", end="2026-04-26T09:01:00+08:00")
+        _insert_block(conn, start="2026-04-26T09:25:00+08:00", end="2026-04-26T09:26:00+08:00")
+        # Blocks attributable to B (must NOT count toward A's end_time)
+        _insert_block(conn, start="2026-04-26T09:35:00+08:00", end="2026-04-26T09:36:00+08:00")
+        _insert_block(conn, start="2026-04-26T09:50:00+08:00", end="2026-04-26T09:51:00+08:00")
+
+    assert recovery.recover_orphan_sessions(cfg) == 2
+
+    with fts.cursor() as conn:
+        a = session_store.get_by_id(conn, "sess_a")
+        b = session_store.get_by_id(conn, "sess_b")
+        assert a is not None and b is not None
+        assert a.end_time == _ts("2026-04-26T09:26:00+08:00"), (
+            "A should end at its own last block, not bleed into B's window"
+        )
+        assert b.end_time == _ts("2026-04-26T09:51:00+08:00")
+
+
+def test_recover_caps_at_max_session_hours(ac_root: Path) -> None:
+    """A wildly distant block must not stretch the orphan past max_session_hours.
+
+    A timeline block from a totally unrelated future moment (e.g. a
+    later session that somehow lost its row) shouldn't pull the
+    orphan's end_time past the SessionManager's physical session
+    ceiling.
+    """
+    cfg = _cfg(ac_root)
+    # max_session_hours default is 2; place a stray block 5h after start.
+    start = "2026-04-26T09:00:00+08:00"
+    far_block = "2026-04-26T14:30:00+08:00"
+    with fts.cursor() as conn:
+        _insert_active(conn, session_id="sess_a", start=start)
+        _insert_block(conn, start=far_block, end="2026-04-26T14:31:00+08:00")
+
+    assert recovery.recover_orphan_sessions(cfg) == 1
+
+    with fts.cursor() as conn:
+        row = session_store.get_by_id(conn, "sess_a")
+        assert row is not None
+        # No block exists inside [start, start+2h], so we fall back to
+        # the 1-min empty-session sentinel.
+        assert row.end_time == _ts(start) + timedelta(minutes=1)
+
+
+def test_recover_is_idempotent(ac_root: Path) -> None:
+    """Calling twice: second call sees no active rows, no changes."""
+    cfg = _cfg(ac_root)
+    with fts.cursor() as conn:
+        _insert_active(conn, session_id="sess_a", start="2026-04-26T09:00:00+08:00")
+
+    assert recovery.recover_orphan_sessions(cfg) == 1
+    assert recovery.recover_orphan_sessions(cfg) == 0
+
+    with fts.cursor() as conn:
+        row = session_store.get_by_id(conn, "sess_a")
+        assert row is not None
+        assert row.status == "ended"
+
+
+def test_recovered_session_visible_to_reduce_all_pending_query(ac_root: Path) -> None:
+    """After recovery the row matches the safety-net's catch-up SQL.
+
+    This is the integration check: ``list_pending_reduction`` is the
+    query the daily safety-net uses, and it filters
+    ``status IN ('ended', 'failed') AND end_time IS NOT NULL``.
+    The recovery's whole point is to flip the orphan from ``active`` →
+    ``ended`` so this query picks it up.
+    """
+    cfg = _cfg(ac_root)
+    with fts.cursor() as conn:
+        _insert_active(conn, session_id="sess_a", start="2026-04-26T09:00:00+08:00")
+        _insert_block(conn, start="2026-04-26T09:00:00+08:00", end="2026-04-26T09:01:00+08:00")
+
+    recovery.recover_orphan_sessions(cfg)
+
+    with fts.cursor() as conn:
+        pending = session_store.list_pending_reduction(conn)
+        assert len(pending) == 1
+        assert pending[0].id == "sess_a"
+        assert pending[0].status == "ended"
+        assert pending[0].end_time is not None

--- a/tests/test_session_recovery.py
+++ b/tests/test_session_recovery.py
@@ -155,6 +155,40 @@ def test_recover_is_idempotent(ac_root: Path) -> None:
         assert row.status == "ended"
 
 
+def test_recover_blockless_orphan_clamps_fallback_to_next_session_start(
+    ac_root: Path,
+) -> None:
+    """The 1-min fallback must not overlap with the next session.
+
+    Back-to-back hard crashes can leave two orphans whose start_times
+    are within a minute of each other. If A has no persisted blocks,
+    the unclamped ``start + 1min`` fallback would push A.end_time past
+    B.start, and the eventual reducer pass over [A.start, A.end) would
+    double-attribute B's first block. Clamping the fallback to the
+    upper bound (= B.start) keeps sessions disjoint.
+    """
+    cfg = _cfg(ac_root)
+    a_start = "2026-04-26T09:00:00+08:00"
+    b_start = "2026-04-26T09:00:30+08:00"
+    with fts.cursor() as conn:
+        _insert_active(conn, session_id="sess_a", start=a_start)
+        _insert_active(conn, session_id="sess_b", start=b_start)
+        # No blocks at all — both orphans go through the fallback path.
+
+    assert recovery.recover_orphan_sessions(cfg) == 2
+
+    with fts.cursor() as conn:
+        a = session_store.get_by_id(conn, "sess_a")
+        b = session_store.get_by_id(conn, "sess_b")
+        assert a is not None and b is not None
+        assert a.end_time == _ts(b_start), (
+            "A's fallback end_time must be clamped to B.start, not pushed "
+            "1 minute past it"
+        )
+        # B has no successor so its fallback is the unclamped 1-min default.
+        assert b.end_time == _ts(b_start) + timedelta(minutes=1)
+
+
 def test_recovered_session_visible_to_reduce_all_pending_query(ac_root: Path) -> None:
     """After recovery the row matches the safety-net's catch-up SQL.
 


### PR DESCRIPTION
## Summary — silent data loss across hard crashes

The graceful shutdown path calls `SessionManager.force_end` so any in-progress session is persisted as `ended` before exit. **A SIGKILL / OOM kill / kernel panic / power loss skips that** — the `sessions` row stays at `status='active'` with `end_time=NULL`, and the daily safety-net's `reduce_all_pending` query explicitly excludes `active` rows:

```python
# session/store.py:list_pending_reduction
WHERE status IN ('ended', 'failed') AND end_time IS NOT NULL
```

The session is then **never reduced, never classified, and silently absent from `event-*.md`** — a full block of the user's day is lost without any error or log entry. The bug surfaces only when reproduced: `kill -9` the daemon mid-session, restart, watch the orphan row sit forever.

## Fix

`session/recovery.recover_orphan_sessions(cfg)` runs once at daemon startup, **before** `build_manager` (so the new `SessionManager` can't race the recovery). It lists every `active` row, infers a plausible `end_time` from the timeline blocks the previous run did persist, and force-ends each row so the existing catch-up machinery picks it up on the next pass.

End-time inference adds two SQL helpers:
- **`timeline_store.latest_end_in_window(conn, start, end)`** — most recent block end whose `start_time ∈ [start, end)`.
- **`session_store.next_session_start_after(conn, start_time)`** — earliest `start_time` of any session that opened after this one. Used as the upper bound so two consecutive orphans (e.g. two crashes with one normal session in between) don't claim each other's blocks.

The inferred window is `[start_time, min(next_session_start, start_time + max_session_hours))`. If no block exists in that window (the crash beat the 1-min aggregator), end_time falls back to `start_time + 1 minute` and the reducer's empty-window branch marks the row `reduced` as a no-op — the orphan is gone either way.

## Out of scope (intentionally)

- **Firing the reducer immediately on startup.** Recovered sessions are reduced by the next daily safety-net tick (worst case ~24h latency). A faster-recovery follow-up can fold in the `on_done` + classifier wiring without changing the storage layer.
- **Age-based filtering.** Even year-old orphans are recovered; if the blocks have been pruned, the empty-window branch cleans them up naturally.

## Relationship to #11 / #12

Independent — different files (`daemon.py`, `session/`, `timeline/store.py`), no overlap. Mergeable in any order.

## Test plan

- [x] `uv run pytest` — 76/76 (69 existing + 7 new)
- [x] `uv run ruff check src/ tests/test_session_recovery.py` — clean
- [x] Edge case manually traced: two consecutive hard-crashes with one good session in the middle — `next_session_start_after` query is status-agnostic, so the good session's start still bounds the older orphan's window. Working correctly.

New tests:
- `test_recover_no_orphans_is_noop`
- `test_recover_orphan_with_blocks_uses_latest_block_end`
- `test_recover_orphan_with_no_blocks_uses_one_minute_fallback`
- `test_recover_two_orphans_dont_pollute_each_other` ← **the key edge case**: A's window must not extend into B's blocks. Without `next_session_start_after` this would fail.
- `test_recover_caps_at_max_session_hours`
- `test_recover_is_idempotent`
- `test_recovered_session_visible_to_reduce_all_pending_query` — integration check that the recovered row matches the safety-net's catch-up SQL.