### PR TITLE
fix(cli): remove stale capture index rows

### DIFF
--- a/src/openchronicle/cli.py
+++ b/src/openchronicle/cli.py
@@ -916,10 +916,19 @@ def rebuild_captures_index() -> None:
     _init()
     buf = paths.capture_buffer_dir()
     if not buf.exists():
+        with fts.cursor() as conn:
+            conn.execute("DELETE FROM captures")
         console.print("[yellow]No capture-buffer directory; nothing to rebuild.[/yellow]")
         return
 
     files = sorted(p for p in buf.iterdir() if p.is_file() and p.suffix == ".json")
+    file_ids = {p.stem for p in files}
+    with fts.cursor() as conn:
+        rows = conn.execute("SELECT id FROM captures").fetchall()
+        for row in rows:
+            if row["id"] not in file_ids:
+                fts.delete_capture(conn, row["id"])
+
     if not files:
         console.print("[yellow]capture-buffer is empty; nothing to rebuild.[/yellow]")
         return
@@ -994,11 +1003,17 @@ def _clean_captures() -> int:
     buf = paths.capture_buffer_dir()
     if not buf.exists():
         return 0
+    removed_stems: list[str] = []
     n = 0
     for p in buf.iterdir():
         if p.suffix == ".json" and p.is_file():
             p.unlink()
+            removed_stems.append(p.stem)
             n += 1
+    if removed_stems:
+        with fts.cursor() as conn:
+            for stem in removed_stems:
+                fts.delete_capture(conn, stem)
     return n
 
 

--- a/src/openchronicle/cli.py
+++ b/src/openchronicle/cli.py
@@ -925,9 +925,8 @@ def rebuild_captures_index() -> None:
     file_ids = {p.stem for p in files}
     with fts.cursor() as conn:
         rows = conn.execute("SELECT id FROM captures").fetchall()
-        for row in rows:
-            if row["id"] not in file_ids:
-                fts.delete_capture(conn, row["id"])
+    stale_ids = [row["id"] for row in rows if row["id"] not in file_ids]
+    _delete_capture_rows(stale_ids)
 
     if not files:
         console.print("[yellow]capture-buffer is empty; nothing to rebuild.[/yellow]")
@@ -999,6 +998,28 @@ def _warn_if_running() -> None:
         )
 
 
+def _delete_capture_rows(capture_ids: list[str]) -> None:
+    """Delete capture rows in one explicit transaction.
+
+    fts.connect uses autocommit mode, so sqlite3's connection context manager
+    does not open a transaction for us here.
+    """
+    if not capture_ids:
+        return
+    with fts.cursor() as conn:
+        conn.execute("BEGIN")
+        try:
+            conn.executemany(
+                "DELETE FROM captures WHERE id=?",
+                ((capture_id,) for capture_id in capture_ids),
+            )
+            conn.execute("COMMIT")
+        except Exception:  # noqa: BLE001
+            if conn.in_transaction:
+                conn.execute("ROLLBACK")
+            raise
+
+
 def _clean_captures() -> int:
     buf = paths.capture_buffer_dir()
     if not buf.exists():
@@ -1010,10 +1031,7 @@ def _clean_captures() -> int:
             p.unlink()
             removed_stems.append(p.stem)
             n += 1
-    if removed_stems:
-        with fts.cursor() as conn:
-            for stem in removed_stems:
-                fts.delete_capture(conn, stem)
+    _delete_capture_rows(removed_stems)
     return n
 
 

--- a/tests/test_cli_captures_cleanup.py
+++ b/tests/test_cli_captures_cleanup.py
@@ -1,0 +1,89 @@
+from __future__ import annotations
+
+import json
+
+from openchronicle import cli
+
+
+def test_clean_captures_removes_matching_index_rows(ac_root) -> None:
+    from openchronicle import paths
+    from openchronicle.store import fts
+
+    capture = {
+        "timestamp": "2026-04-25T22:01:00+08:00",
+        "window_meta": {"app_name": "Chrome", "title": "Python docs"},
+        "visible_text": "urllib.parse docs",
+    }
+    capture_path = paths.capture_buffer_dir() / "normal.json"
+    capture_path.write_text(json.dumps(capture), encoding="utf-8")
+    with fts.cursor() as conn:
+        fts.insert_capture(
+            conn,
+            id="normal",
+            timestamp=capture["timestamp"],
+            app_name="Chrome",
+            bundle_id="",
+            window_title="Python docs",
+            focused_role="",
+            focused_value="",
+            visible_text="urllib.parse docs",
+            url="https://docs.python.org",
+        )
+
+    deleted = cli._clean_captures()
+
+    assert deleted == 1
+    assert not capture_path.exists()
+    with fts.cursor() as conn:
+        rows = conn.execute("SELECT id FROM captures").fetchall()
+    assert rows == []
+
+
+def test_rebuild_captures_index_drops_rows_for_missing_files(ac_root, monkeypatch) -> None:
+    from openchronicle import paths
+    from openchronicle.store import fts
+
+    monkeypatch.setattr(cli, "_init", lambda: None)
+
+    kept_capture = {
+        "timestamp": "2026-04-25T22:01:00+08:00",
+        "window_meta": {"app_name": "Chrome", "title": "Python docs"},
+        "visible_text": "urllib.parse docs",
+    }
+    kept_path = paths.capture_buffer_dir() / "kept.json"
+    kept_path.write_text(json.dumps(kept_capture), encoding="utf-8")
+    with fts.cursor() as conn:
+        fts.insert_capture(
+            conn,
+            id="kept",
+            timestamp=kept_capture["timestamp"],
+            app_name="Chrome",
+            bundle_id="",
+            window_title="Old title",
+            focused_role="",
+            focused_value="",
+            visible_text="old text",
+            url="",
+        )
+        fts.insert_capture(
+            conn,
+            id="stale",
+            timestamp="2026-04-25T22:00:00+08:00",
+            app_name="Chrome",
+            bundle_id="",
+            window_title="Deleted page",
+            focused_role="",
+            focused_value="",
+            visible_text="deleted text",
+            url="",
+        )
+
+    cli.rebuild_captures_index()
+
+    with fts.cursor() as conn:
+        rows = conn.execute(
+            "SELECT id, window_title, visible_text FROM captures ORDER BY id"
+        ).fetchall()
+    assert [(row["id"], row["window_title"], row["visible_text"]) for row in rows] == [
+        ("kept", "Python docs", "urllib.parse docs")
+    ]


### PR DESCRIPTION
## Summary

Fix stale rows in the `captures` SQLite table when capture JSON files are removed.

Changes:
- `clean captures` now deletes matching `captures` rows after removing `capture-buffer/*.json`
- `rebuild-captures-index` now removes rows whose capture files no longer exist
- adds regression tests for cleanup and rebuild behavior

## Tests

- `python -m pytest tests/test_cli_captures_cleanup.py -q`
- `python -m ruff check src/openchronicle/cli.py tests/test_cli_captures_cleanup.py`