### PR TITLE
fix(writer): avoid compact overwriting concurrent writes

### DIFF
--- a/src/openchronicle/writer/compact.py
+++ b/src/openchronicle/writer/compact.py
@@ -88,6 +88,8 @@ def compact_file(cfg: Config, conn: sqlite3.Connection, *, name: str) -> Compact
         )
     compacted.metadata["needs_compact"] = False
     new_text = frontmatter.dumps(compacted) + "\n"
+    compacted_entries = files_mod._parse_entries(compacted.content)
+    prefix = files_mod.validate_prefix(path.name)
 
     after_unique = _unique_tokens(new_text)
     preserved = len(before_unique & after_unique)
@@ -128,34 +130,39 @@ def compact_file(cfg: Config, conn: sqlite3.Connection, *, name: str) -> Compact
 
         # Re-ingest this file's entries into FTS while still holding the same
         # file lock so on-disk Markdown and index rows move forward together.
-        fts.delete_entries_for(conn, path.name)
-        parsed = files_mod.read_file(path)
-        prefix = files_mod.validate_prefix(path.name)
-        fts.upsert_file(
-            conn,
-            fts.FileRow(
-                path=path.name,
-                prefix=prefix,
-                description=parsed.description,
-                tags=" ".join(parsed.tags),
-                status=parsed.status,
-                entry_count=len(parsed.entries),
-                created=parsed.created,
-                updated=parsed.updated,
-                needs_compact=0,
-            ),
-        )
-        for e in parsed.entries:
-            fts.insert_entry(
+        conn.execute("SAVEPOINT compact_file_fts")
+        try:
+            fts.delete_entries_for(conn, path.name)
+            fts.upsert_file(
                 conn,
-                id=e.id,
-                path=path.name,
-                prefix=prefix,
-                timestamp=e.timestamp,
-                tags=" ".join(e.tags),
-                content=entries_mod._strip_strike(e.body),
-                superseded=1 if e.superseded_by else 0,
+                fts.FileRow(
+                    path=path.name,
+                    prefix=prefix,
+                    description=str(compacted.metadata.get("description", "")),
+                    tags=" ".join(compacted.metadata.get("tags", []) or []),
+                    status=str(compacted.metadata.get("status", "active")),
+                    entry_count=len(compacted_entries),
+                    created=str(compacted.metadata.get("created", "")),
+                    updated=str(compacted.metadata.get("updated", "")),
+                    needs_compact=0,
+                ),
             )
+            for e in compacted_entries:
+                fts.insert_entry(
+                    conn,
+                    id=e.id,
+                    path=path.name,
+                    prefix=prefix,
+                    timestamp=e.timestamp,
+                    tags=" ".join(e.tags),
+                    content=entries_mod._strip_strike(e.body),
+                    superseded=1 if e.superseded_by else 0,
+                )
+        except Exception:
+            conn.execute("ROLLBACK TO SAVEPOINT compact_file_fts")
+            conn.execute("RELEASE SAVEPOINT compact_file_fts")
+            raise
+        conn.execute("RELEASE SAVEPOINT compact_file_fts")
 
     logger.info(
         "compact accepted: %s  %d→%d tokens (%.1f%% preservation)",

--- a/src/openchronicle/writer/compact.py
+++ b/src/openchronicle/writer/compact.py
@@ -10,6 +10,8 @@ import re
 import sqlite3
 from dataclasses import dataclass
 
+import frontmatter
+
 from ..config import Config
 from ..logger import get
 from ..prompts import load as load_prompt
@@ -77,6 +79,16 @@ def compact_file(cfg: Config, conn: sqlite3.Connection, *, name: str) -> Compact
             len(before_unique), 0, 0.0, "response missing frontmatter — rejected",
         )
 
+    try:
+        compacted = frontmatter.loads(new_text)
+    except Exception as exc:  # noqa: BLE001
+        return CompactResult(
+            name, False, before_tokens, len(new_text) // 4,
+            len(before_unique), 0, 0.0, f"frontmatter parse error: {exc}",
+        )
+    compacted.metadata["needs_compact"] = False
+    new_text = frontmatter.dumps(compacted) + "\n"
+
     after_unique = _unique_tokens(new_text)
     preserved = len(before_unique & after_unique)
     ratio = preserved / len(before_unique) if before_unique else 1.0
@@ -92,42 +104,58 @@ def compact_file(cfg: Config, conn: sqlite3.Connection, *, name: str) -> Compact
             f"rejected: preservation {ratio:.1%} < {_PRESERVATION_THRESHOLD:.0%}",
         )
 
-    # Accept: write back, clear flag, update FTS by doing per-file rebuild
-    files_mod.atomic_write_text(
-        path, new_text if new_text.endswith("\n") else new_text + "\n"
-    )
+    # Accept only if the file is still the same one the LLM saw. The LLM call
+    # can take tens of seconds; reducers/classifiers may append while it runs.
+    # Overwriting after a stale read would silently drop those new entries.
+    with files_mod.file_lock(path):
+        try:
+            current = path.read_text()
+        except FileNotFoundError:
+            return CompactResult(
+                name, False, before_tokens, before_tokens,
+                len(before_unique), len(before_unique), 1.0,
+                "file missing before writeback",
+            )
+        if current != original:
+            logger.info("compact skipped: %s changed during LLM rewrite", name)
+            return CompactResult(
+                name, False, before_tokens, before_tokens,
+                len(before_unique), len(before_unique), 1.0,
+                "file changed during compact — retry later",
+            )
 
-    # Re-ingest this file's entries into FTS
-    fts.delete_entries_for(conn, path.name)
-    parsed = files_mod.read_file(path)
-    prefix = files_mod.validate_prefix(path.name)
-    fts.upsert_file(
-        conn,
-        fts.FileRow(
-            path=path.name,
-            prefix=prefix,
-            description=parsed.description,
-            tags=" ".join(parsed.tags),
-            status=parsed.status,
-            entry_count=len(parsed.entries),
-            created=parsed.created,
-            updated=parsed.updated,
-            needs_compact=0,
-        ),
-    )
-    for e in parsed.entries:
-        fts.insert_entry(
+        files_mod.atomic_write_text(path, new_text)
+
+        # Re-ingest this file's entries into FTS while still holding the same
+        # file lock so on-disk Markdown and index rows move forward together.
+        fts.delete_entries_for(conn, path.name)
+        parsed = files_mod.read_file(path)
+        prefix = files_mod.validate_prefix(path.name)
+        fts.upsert_file(
             conn,
-            id=e.id,
-            path=path.name,
-            prefix=prefix,
-            timestamp=e.timestamp,
-            tags=" ".join(e.tags),
-            content=entries_mod._strip_strike(e.body),
-            superseded=1 if e.superseded_by else 0,
+            fts.FileRow(
+                path=path.name,
+                prefix=prefix,
+                description=parsed.description,
+                tags=" ".join(parsed.tags),
+                status=parsed.status,
+                entry_count=len(parsed.entries),
+                created=parsed.created,
+                updated=parsed.updated,
+                needs_compact=0,
+            ),
         )
-    # Clear frontmatter flag
-    files_mod.update_frontmatter(path, {"needs_compact": False})
+        for e in parsed.entries:
+            fts.insert_entry(
+                conn,
+                id=e.id,
+                path=path.name,
+                prefix=prefix,
+                timestamp=e.timestamp,
+                tags=" ".join(e.tags),
+                content=entries_mod._strip_strike(e.body),
+                superseded=1 if e.superseded_by else 0,
+            )
 
     logger.info(
         "compact accepted: %s  %d→%d tokens (%.1f%% preservation)",

--- a/tests/test_store.py
+++ b/tests/test_store.py
@@ -5,9 +5,16 @@ from unittest.mock import patch
 
 import pytest
 
+from openchronicle.config import Config
 from openchronicle.store import entries as entries_mod
 from openchronicle.store import files as files_mod
 from openchronicle.store import fts, index_md
+from openchronicle.writer import compact as compact_mod
+
+
+class _LLMTextResponse:
+    def __init__(self, content: str) -> None:
+        self.choices = [type("_Choice", (), {"message": type("_Msg", (), {"content": content})()})()]
 
 
 def test_make_id_uniqueness() -> None:
@@ -298,3 +305,73 @@ def test_concurrent_supersede_then_append_serializes(ac_root: Path) -> None:
         f"expected 3 entries, got {len(parsed.entries)} — interleaved writes "
         f"likely lost or corrupted one"
     )
+
+
+def test_compact_accepts_when_file_unchanged(ac_root: Path) -> None:
+    name = "topic-compact.md"
+    with fts.cursor() as conn:
+        entries_mod.create_file(conn, name=name, description="compact target", tags=["topic"])
+        entries_mod.append_entry(
+            conn,
+            name=name,
+            content=(
+                "AlphaProject BetaRoadmap GammaDecision DeltaTimeline "
+                "EpsilonMemory ZetaCapture EtaClassifier ThetaReducer."
+            ),
+            tags=["topic"],
+        )
+        path = files_mod.memory_path(name)
+        files_mod.update_frontmatter(path, {"needs_compact": True})
+        fts.set_needs_compact(conn, name, True)
+
+        with patch("openchronicle.writer.compact.llm_mod.call_llm") as call_llm:
+            call_llm.return_value = _LLMTextResponse(path.read_text())
+            result = compact_mod.compact_file(Config(), conn, name=name)
+
+        assert result.accepted is True
+        parsed = files_mod.read_file(path)
+        assert parsed.needs_compact is False
+        assert fts.get_file(conn, name).needs_compact == 0
+
+
+def test_compact_skips_if_file_changes_during_llm_rewrite(ac_root: Path) -> None:
+    """Compaction must not overwrite entries appended while the LLM is running."""
+    name = "topic-compact-race.md"
+    with fts.cursor() as conn:
+        entries_mod.create_file(conn, name=name, description="compact race", tags=["topic"])
+        entries_mod.append_entry(
+            conn,
+            name=name,
+            content=(
+                "AlphaProject BetaRoadmap GammaDecision DeltaTimeline "
+                "EpsilonMemory ZetaCapture EtaClassifier ThetaReducer."
+            ),
+            tags=["topic"],
+        )
+        path = files_mod.memory_path(name)
+        files_mod.update_frontmatter(path, {"needs_compact": True})
+        fts.set_needs_compact(conn, name, True)
+
+        def append_during_rewrite(*args, **kwargs) -> _LLMTextResponse:
+            stale_rewrite = path.read_text()
+            with fts.cursor() as append_conn:
+                entries_mod.append_entry(
+                    append_conn,
+                    name=name,
+                    content="ConcurrentAppendToken must survive compaction.",
+                    tags=["topic"],
+                )
+            return _LLMTextResponse(stale_rewrite)
+
+        with patch(
+            "openchronicle.writer.compact.llm_mod.call_llm",
+            side_effect=append_during_rewrite,
+        ):
+            result = compact_mod.compact_file(Config(), conn, name=name)
+
+    assert result.accepted is False
+    assert "changed during compact" in result.note
+    parsed = files_mod.read_file(files_mod.memory_path(name))
+    bodies = "\n".join(e.body for e in parsed.entries)
+    assert "ConcurrentAppendToken" in bodies
+    assert parsed.needs_compact is True


### PR DESCRIPTION
## Summary

`compact_file` reads a memory file, sends it to the LLM, then writes the compacted result back. That LLM call can take long enough for a reducer/classifier append to land on the same file in the meantime. Before this change, the stale compacted output could overwrite those newer entries.

This PR adds a compare-and-swap style writeback:

- read the original file before the LLM rewrite
- parse and clear `needs_compact` in the compacted output before writing
- take the existing per-file lock before writeback
- re-read the file and skip compaction if it changed while the LLM was running
- rebuild the file's FTS rows while still holding the same file lock after an accepted compact

If the file changed, compaction is left for a later retry instead of risking data loss.

## Tests

- `uv run pytest tests/test_store.py -q`
- `uv run ruff check src/openchronicle/writer/compact.py tests/test_store.py`
- `uv run pytest -q`