### PR TITLE
feat(capture): support per-app/per-URL capture exclusions

### DIFF
--- a/docs/config.md
+++ b/docs/config.md
@@ -109,6 +109,25 @@ Tuning notes:
 - **`screenshot_retention_hours`.** After this many hours the screenshot field is stripped (rest of the JSON stays). Screenshots aren't used by timeline / reducer / classifier today — setting this ≪ `buffer_retention_hours` is what makes long retention cheap. `0` or very large values keep screenshots for the full window.
 - **`buffer_max_mb`.** Hard ceiling in MB. When exceeded, the cleanup pass evicts oldest absorbed files until under. Set to `0` to disable (pure time-based retention).
 
+### Privacy exclusions
+
+```toml
+[capture]
+excluded_window_title_patterns = ["Incognito", "Private Browsing", "InPrivate", "1Password"]
+excluded_app_names             = ["Signal"]
+excluded_bundle_ids            = ["com.apple.keychainaccess"]
+```
+
+Matching windows are skipped entirely — no AX query, no screenshot, no JSON written, no FTS row indexed. All three lists default to empty (no exclusions).
+
+| Field | Match semantics |
+|---|---|
+| `excluded_window_title_patterns` | Case-insensitive **substring** match against the window title. Empty strings are ignored. |
+| `excluded_app_names` | Case-insensitive **exact** match against the app name (e.g. `"Signal"` matches `Signal` but not `Signal Beta`). |
+| `excluded_bundle_ids` | Case-insensitive **exact** match against the macOS bundle identifier. |
+
+When a window is excluded, only the app name and bundle ID are logged (not the window title) to preserve the privacy intent.
+
 ## `[timeline]`
 
 ```toml

--- a/src/openchronicle/capture/scheduler.py
+++ b/src/openchronicle/capture/scheduler.py
@@ -45,7 +45,7 @@ def _is_excluded(cfg: CaptureConfig, meta: window_meta.WindowMeta) -> bool:
         return True
     if cfg.excluded_window_title_patterns and meta.title:
         title_lower = meta.title.lower()
-        if any(p.lower() in title_lower for p in cfg.excluded_window_title_patterns):
+        if any(p and p.lower() in title_lower for p in cfg.excluded_window_title_patterns):
             return True
     return False
 
@@ -66,8 +66,8 @@ def _build_capture(
 
     if _is_excluded(cfg, meta):
         logger.info(
-            "capture skipped (excluded): app=%r title=%r bundle=%r",
-            meta.app_name, meta.title[:60], meta.bundle_id,
+            "capture skipped (excluded): app=%r bundle=%r",
+            meta.app_name, meta.bundle_id,
         )
         return None
 

--- a/src/openchronicle/capture/scheduler.py
+++ b/src/openchronicle/capture/scheduler.py
@@ -33,6 +33,23 @@ def _safe_filename(ts: str) -> str:
     return ts.replace(":", "-").replace("+", "p")
 
 
+def _is_excluded(cfg: CaptureConfig, meta: window_meta.WindowMeta) -> bool:
+    """Return True if the active window matches any exclusion rule."""
+    if cfg.excluded_app_names and meta.app_name.lower() in (
+        n.lower() for n in cfg.excluded_app_names
+    ):
+        return True
+    if cfg.excluded_bundle_ids and meta.bundle_id.lower() in (
+        b.lower() for b in cfg.excluded_bundle_ids
+    ):
+        return True
+    if cfg.excluded_window_title_patterns and meta.title:
+        title_lower = meta.title.lower()
+        if any(p.lower() in title_lower for p in cfg.excluded_window_title_patterns):
+            return True
+    return False
+
+
 def _build_capture(
     cfg: CaptureConfig,
     provider: ax_capture.AXProvider,
@@ -45,6 +62,15 @@ def _build_capture(
         logger.info("capture skipped (paused)")
         return None
 
+    meta = window_meta.active_window()
+
+    if _is_excluded(cfg, meta):
+        logger.info(
+            "capture skipped (excluded): app=%r title=%r bundle=%r",
+            meta.app_name, meta.title[:60], meta.bundle_id,
+        )
+        return None
+
     ts = _now_iso()
     out: dict[str, Any] = {
         "timestamp": ts,
@@ -52,7 +78,6 @@ def _build_capture(
         "trigger": trigger or {"event_type": "heartbeat"},
     }
 
-    meta = window_meta.active_window()
     out["window_meta"] = {
         "app_name": meta.app_name,
         "title": meta.title,

--- a/src/openchronicle/config.py
+++ b/src/openchronicle/config.py
@@ -47,6 +47,12 @@ class CaptureConfig:
     screenshot_jpeg_quality: int = 80
     ax_depth: int = 100
     ax_timeout_seconds: int = 3
+    # Privacy exclusions — matching windows are skipped entirely (no AX, no
+    # screenshot, no JSON, no FTS row).  Title patterns use case-insensitive
+    # substring match; app names and bundle IDs use case-insensitive exact match.
+    excluded_window_title_patterns: list[str] = field(default_factory=list)
+    excluded_app_names: list[str] = field(default_factory=list)
+    excluded_bundle_ids: list[str] = field(default_factory=list)
 
 
 @dataclass
@@ -242,6 +248,9 @@ screenshot_max_width = 1920
 screenshot_jpeg_quality = 80
 ax_depth = 100                # Electron apps (Claude Desktop, VS Code, Slack) have deep DOM; 8 only reaches the chrome
 ax_timeout_seconds = 3
+# excluded_window_title_patterns = ["Incognito", "Private Browsing", "InPrivate", "1Password"]
+# excluded_app_names             = ["Signal"]
+# excluded_bundle_ids            = ["com.apple.keychainaccess"]
 
 [timeline]
 window_minutes = 1             # length of each aggregator block (verbatim-preserving normalizer)

--- a/tests/test_capture_scheduler_fts.py
+++ b/tests/test_capture_scheduler_fts.py
@@ -5,8 +5,11 @@ from __future__ import annotations
 import os
 import time
 from pathlib import Path
+from unittest.mock import patch
 
 from openchronicle.capture import scheduler as scheduler_mod
+from openchronicle.capture import window_meta
+from openchronicle.config import CaptureConfig
 from openchronicle.store import fts
 
 
@@ -111,3 +114,82 @@ def test_cleanup_eviction_also_drops_fts(ac_root: Path) -> None:
     assert len(remaining) == 3 - stats["evicted"]
     # Newest survives.
     assert written[-1].stem in remaining
+
+
+# ---------------------------------------------------------------------------
+# Capture exclusion rules
+# ---------------------------------------------------------------------------
+
+
+class _FakeProvider:
+    available = False
+
+
+def _exclusion_cfg(**overrides) -> CaptureConfig:
+    defaults = dict(
+        include_screenshot=False,
+        excluded_window_title_patterns=[],
+        excluded_app_names=[],
+        excluded_bundle_ids=[],
+    )
+    defaults.update(overrides)
+    return CaptureConfig(**defaults)
+
+
+def test_excluded_app_name_skips_capture(ac_root: Path) -> None:
+    cfg = _exclusion_cfg(excluded_app_names=["Signal"])
+    fake_meta = window_meta.WindowMeta(app_name="Signal", title="Chat", bundle_id="org.signal.desktop")
+    with patch("openchronicle.capture.scheduler.window_meta.active_window", return_value=fake_meta):
+        result = scheduler_mod._build_capture(cfg, _FakeProvider(), trigger=None)
+    assert result is None
+
+
+def test_excluded_bundle_id_skips_capture(ac_root: Path) -> None:
+    cfg = _exclusion_cfg(excluded_bundle_ids=["com.apple.keychainaccess"])
+    fake_meta = window_meta.WindowMeta(
+        app_name="Keychain Access", title="Passwords",
+        bundle_id="com.apple.keychainaccess",
+    )
+    with patch("openchronicle.capture.scheduler.window_meta.active_window", return_value=fake_meta):
+        result = scheduler_mod._build_capture(cfg, _FakeProvider(), trigger=None)
+    assert result is None
+
+
+def test_excluded_title_pattern_skips_capture(ac_root: Path) -> None:
+    cfg = _exclusion_cfg(excluded_window_title_patterns=["Incognito", "Private Browsing"])
+    fake_meta = window_meta.WindowMeta(
+        app_name="Google Chrome",
+        title="GitHub - Google Chrome - Incognito",
+        bundle_id="com.google.chrome",
+    )
+    with patch("openchronicle.capture.scheduler.window_meta.active_window", return_value=fake_meta):
+        result = scheduler_mod._build_capture(cfg, _FakeProvider(), trigger=None)
+    assert result is None
+
+
+def test_non_excluded_window_proceeds(ac_root: Path) -> None:
+    cfg = _exclusion_cfg(
+        excluded_app_names=["Signal"],
+        excluded_window_title_patterns=["Incognito"],
+    )
+    fake_meta = window_meta.WindowMeta(app_name="Cursor", title="main.py", bundle_id="com.todesktop")
+    with patch("openchronicle.capture.scheduler.window_meta.active_window", return_value=fake_meta):
+        result = scheduler_mod._build_capture(cfg, _FakeProvider(), trigger=None)
+    assert result is not None
+    assert result["window_meta"]["app_name"] == "Cursor"
+
+
+def test_exclusion_is_case_insensitive(ac_root: Path) -> None:
+    cfg = _exclusion_cfg(excluded_app_names=["signal"])
+    fake_meta = window_meta.WindowMeta(app_name="Signal", title="Chat", bundle_id="org.signal.desktop")
+    with patch("openchronicle.capture.scheduler.window_meta.active_window", return_value=fake_meta):
+        result = scheduler_mod._build_capture(cfg, _FakeProvider(), trigger=None)
+    assert result is None
+
+
+def test_exclusion_with_empty_title_does_not_match_pattern(ac_root: Path) -> None:
+    cfg = _exclusion_cfg(excluded_window_title_patterns=["Incognito"])
+    fake_meta = window_meta.WindowMeta(app_name="Chrome", title="", bundle_id="com.google.chrome")
+    with patch("openchronicle.capture.scheduler.window_meta.active_window", return_value=fake_meta):
+        result = scheduler_mod._build_capture(cfg, _FakeProvider(), trigger=None)
+    assert result is not None

--- a/tests/test_capture_scheduler_fts.py
+++ b/tests/test_capture_scheduler_fts.py
@@ -193,3 +193,12 @@ def test_exclusion_with_empty_title_does_not_match_pattern(ac_root: Path) -> Non
     with patch("openchronicle.capture.scheduler.window_meta.active_window", return_value=fake_meta):
         result = scheduler_mod._build_capture(cfg, _FakeProvider(), trigger=None)
     assert result is not None
+
+
+def test_exclusion_empty_pattern_does_not_match_all(ac_root: Path) -> None:
+    """An empty string in excluded_window_title_patterns must not match every window."""
+    cfg = _exclusion_cfg(excluded_window_title_patterns=[""])
+    fake_meta = window_meta.WindowMeta(app_name="Cursor", title="main.py", bundle_id="com.todesktop")
+    with patch("openchronicle.capture.scheduler.window_meta.active_window", return_value=fake_meta):
+        result = scheduler_mod._build_capture(cfg, _FakeProvider(), trigger=None)
+    assert result is not None


### PR DESCRIPTION
## Summary

- Add three optional `[capture]` config fields: `excluded_window_title_patterns`, `excluded_app_names`, `excluded_bundle_ids`
- Matching windows are skipped entirely — no AX query, no screenshot, no JSON, no FTS row
- Title patterns: case-insensitive substring match; app names and bundle IDs: case-insensitive exact match
- All default to empty lists, behaviour unchanged unless opted in

## Usage

```toml
[capture]
excluded_window_title_patterns = ["Incognito", "Private Browsing", "InPrivate", "1Password"]
excluded_app_names             = ["Signal"]
excluded_bundle_ids            = ["com.apple.keychainaccess"]
```

## Tests

- `test_excluded_app_name_skips_capture` — exact app name match
- `test_excluded_bundle_id_skips_capture` — exact bundle ID match
- `test_excluded_title_pattern_skips_capture` — substring title match
- `test_non_excluded_window_proceeds` — non-matching windows pass through
- `test_exclusion_is_case_insensitive` — case-insensitive matching
- `test_exclusion_with_empty_title_does_not_match_pattern` — empty title doesn't trigger pattern match

All 111 tests pass, ruff clean.

Closes #27