### PR TITLE
feat(capture): 完善 macOS UserEnter Signal 捕获与生命周期

### DIFF
--- a/docs/capture-fix-validation-2026-07-24.md
+++ b/docs/capture-fix-validation-2026-07-24.md
@@ -1,0 +1,447 @@
+# Capture 修复验证记录（2026-07-24）
+
+## 目的
+
+根据《Open chronicle测试及相关capture修复》中的问题清单，验证本轮
+capture 模块修复：
+
+1. `focused_element` 不再从第一层 AX 节点猜测。
+2. `window_meta.title` 与同一次 AX snapshot 保持一致。
+3. TextEdit 刚激活时正文缺失的情况得到控制。
+4. 内容不变时，连续点击不会制造重复 capture。
+5. 测试数据不进入 timeline、reducer、classifier 或长期 memory。
+
+## 隔离方式
+
+测试使用独立数据根目录：
+
+```text
+/private/tmp/openchronicle-capture-test
+```
+
+配置：
+
+```toml
+[capture]
+event_driven = true
+heartbeat_minutes = 0
+include_screenshot = true
+ax_depth = 100
+ax_timeout_seconds = 3
+
+[reducer]
+enabled = false
+
+[mcp]
+auto_start = false
+```
+
+启动方式：
+
+```bash
+OPENCHRONICLE_ROOT=/tmp/openchronicle-capture-test \
+UV_CACHE_DIR=/tmp/openchronicle-uv-cache \
+uv run openchronicle start --capture-only
+```
+
+验证期间 `timeline.log` 和 `writer.log` 为空，memory 文件数为 0。
+`status` 命令曾执行模型连通性检查，但调用因缺少认证失败；后台 capture
+未进入模型处理流程。
+
+## 自动化验证
+
+代码修改后的完整测试结果：
+
+```text
+112 passed in 1.73s
+```
+
+静态检查：
+
+```text
+Ruff: All checks passed
+git diff --check: passed
+mac-ax-helper: compiled successfully
+```
+
+新增覆盖：
+
+- 不再把第一个 `AXStaticText` 或 `AXTextArea` 猜作焦点。
+- 递归 fallback 只接受明确的 `focused=true`。
+- TextEdit 不完整 AX snapshot 可通过有限重试恢复。
+- 重试期间切换应用时拒绝跨 `bundle_id` 的 snapshot。
+- AX snapshot 标题优先，匹配 trigger 次之，System Events 最后兜底。
+- Chrome 嵌套 `AXComboBox` 地址栏、URL 规范化及页面输入框误判防护。
+- dispatcher 只保留安全的 element 结构字段。
+
+## TextEdit 第一轮：问题复现
+
+测试内容：
+
+```text
+OC_TEXTEDIT_BODY_001
+OpenChronicle capture validation.
+FOCUS_CHECK_001
+```
+
+失败证据：
+
+| Capture 文件 | Trigger | 标题 | 焦点 | 正文标记 | 结论 |
+|---|---|---|---|---|---|
+| `2026-07-24T13-14-21p08-00.json` | `UserTextInput` | `未命名` | 空 | 缺失 | AX 尚未提供正文 |
+| `2026-07-24T13-14-24p08-00.json` | `AXApplicationActivated` | `未命名` | 空 | 缺失 | AX 尚未提供正文 |
+| `2026-07-24T13-14-27p08-00.json` | `AXApplicationActivated` | `未命名` | 空 | 缺失 | AX 尚未提供正文 |
+
+这三帧均能取得 focused window，但 app 级 `focused_element` 为 `null`；
+窗口内只有无子节点的 `AXScrollArea`、Toolbar 和标题，证明缺失发生在
+AX snapshot 层，而不是 S1 parser 丢弃正文。
+
+恢复证据：
+
+| Capture 文件 | Trigger | 焦点 | 正文标记 | 标题来源 |
+|---|---|---|---|---|
+| `2026-07-24T13-14-39p08-00.json` | `UserMouseClick` | `AXTextArea` | 完整 | `ax_snapshot` |
+
+该帧返回 `identifier = First Text View`，正文长度为 70。
+
+## 针对性修复
+
+当交互或应用切换事件产生的 AX snapshot 具有 focused window，但缺少真实
+`focused_element` 时：
+
+1. 等待 150 ms 后重试。
+2. 若仍不完整，再等待 350 ms 重试一次。
+3. 每次重试必须与首帧 `bundle_id` 一致。
+4. 检测到应用已切换时立即停止，并丢弃跨应用 snapshot。
+5. 在 `ax_metadata` 中记录 `retry_count` 和 `app_consistent`。
+
+## TextEdit 第二轮：通过
+
+有效 capture 共 6 帧：
+
+| Capture 文件 | Trigger | 焦点 | 正文 | 标题来源 | Retry | 一致性 |
+|---|---|---|---|---|---:|---|
+| `2026-07-24T13-20-07p08-00.json` | `AXApplicationActivated` | `AXTextArea` | 完整 | `ax_snapshot` | 0 | true |
+| `2026-07-24T13-20-18p08-00.json` | `UserMouseClick` | `AXTextArea` | 完整 | `ax_snapshot` | 0 | true |
+| `2026-07-24T13-20-26p08-00.json` | `UserMouseClick` | `AXTextArea` | 完整 | `ax_snapshot` | 0 | true |
+| `2026-07-24T13-20-33p08-00.json` | `UserMouseClick` | `AXTextArea` | 完整 | `ax_snapshot` | 0 | true |
+| `2026-07-24T13-20-38p08-00.json` | `UserMouseClick` | `AXTextArea` | 完整 | `ax_snapshot` | 0 | true |
+| `2026-07-24T13-20-43p08-00.json` | `AXApplicationActivated` | `AXTextArea` | 完整 | `ax_snapshot` | 0 | true |
+
+所有帧：
+
+- `focused_element.role = AXTextArea`
+- `focused_element.identifier = First Text View`
+- `focused_element.is_editable = true`
+- `focused_element.value_length = 70`
+- 两个测试标记均出现在 `visible_text`
+- `window_meta.title = 未命名`
+- 内容 fingerprint 一致
+- 未发生跨应用 snapshot 混合
+
+`retry_count = 0` 表示第二轮中 AX 首次读取已经完整；有限重试的实际分支由
+自动化测试覆盖。最后连续点击未产生三份额外 TextEdit capture，去重符合预期。
+
+## 当前结论
+
+TextEdit 验收通过。第一轮明确复现了 AX 未稳定问题；加入有限重试和一致性
+保护后，第二轮所有样本均能从首帧取得正确焦点、正文和标题。下一项为
+Chrome URL 与标签页切换验证。
+
+## Chrome 第一轮：URL 与标签页切换通过
+
+测试页面：
+
+```text
+https://example.com/?oc_case=A01
+https://example.org/?oc_case=A02
+```
+
+关键证据：
+
+| Capture 文件 | 操作 | 焦点 | URL | URL 来源 | 一致性 |
+|---|---|---|---|---|---|
+| `2026-07-24T13-43-09p08-00.json` | A01 正文 | 空 | A01 | `ax_address_bar` | true |
+| `2026-07-24T13-43-24p08-00.json` | A01 地址栏 | `AXTextField` | A01 | `ax_address_bar` | true |
+| `2026-07-24T13-43-30p08-00.json` | A01 正文 | 空 | A01 | `ax_address_bar` | true |
+| `2026-07-24T13-43-35p08-00.json` | A02 正文 | 空 | A02 | `ax_address_bar` | true |
+| `2026-07-24T13-43-42p08-00.json` | A02 地址栏 | `AXTextField` | A02 | `ax_address_bar` | true |
+| `2026-07-24T13-43-47p08-00.json` | A02 正文 | 空 | A02 | `ax_address_bar` | true |
+| `2026-07-24T13-43-56p08-00.json` | 标签切至 A01 | 空 | A01 | `ax_address_bar` | true |
+| `2026-07-24T13-44-04p08-00.json` | 标签切至 A02 | 空 | A02 | `ax_address_bar` | true |
+| `2026-07-24T13-44-09p08-00.json` | 标签切至 A01 | 空 | A01 | `ax_address_bar` | true |
+| `2026-07-24T13-44-26p08-00.json` | 最终 A02 点击 | 空 | A02 | `ax_address_bar` | true |
+
+结论：
+
+- 网页正文获得焦点时，仍能从地址栏取得当前 URL。
+- 地址栏获得焦点时返回 `AXTextField`，value 与当前 URL 一致。
+- A01/A02 标签页往返切换时，URL 始终跟随当前标签页。
+- 所有有效样本均为 `title_source = ax_snapshot`、`app_consistent = true`。
+- 页面正文中的链接没有被误认为地址栏 URL。
+- 最后连续点击未产生三份额外 capture。
+
+观察到正文点击样本通常为 `focused_element` 空，但仍触发两次 AX 重试。
+这是性能问题而不是数据正确性问题：Chrome 页面正文没有可编辑焦点时，
+地址栏 URL 和页面 AX 内容已经完整，不需要为了空焦点等待 500 ms。
+
+已修复：浏览器 focused window 已能取得唯一 `ax_address_bar` URL 时，将
+snapshot 视为完整，不再因页面正文缺少 focused element 重试。新增自动化
+测试确认 provider 只调用一次、`retry_count = 0`，同时保留正确 URL。
+修复后全量测试为 `113 passed`。
+
+现场复验通过：
+
+| Capture 文件 | 操作 | 焦点 | URL | URL 来源 | Retry | 一致性 |
+|---|---|---|---|---|---:|---|
+| `2026-07-24T13-51-53p08-00.json` | A02 正文点击 | 空 | A02 | `ax_address_bar` | 0 | true |
+
+与修复前同类正文点击的 `retry_count = 2` 相比，修复后降为 0，URL 和
+snapshot 一致性保持正确。
+
+## Chrome 测试期间发现的隐私问题
+
+隔离测试开始后、正式 A01/A02 用例之前，Chrome 曾打开账户认证页面。原始
+capture 中可能包含邮箱、认证页面可见文字及 URL 查询参数中的临时认证信息。
+这些数据只位于隔离目录，未进入 timeline、writer、模型或长期 memory，
+并且没有复制到本报告。
+
+后续修复应对 URL 查询参数实施敏感键脱敏，并在测试结束后删除隔离目录。
+原始 Chrome 认证 capture 不应提交到 Git 或作为汇报附件。
+
+## 飞书搜索框：未通过
+
+测试词：
+
+```text
+OC_FEISHU_SEARCH_001_X9Q7
+```
+
+测试产生 15 个飞书 capture。窗口标题和应用一致性正常，但搜索框及测试词
+未进入 AX Tree。
+
+关键证据：
+
+| Capture 文件 | 窗口 | Focused element | Retry | 一致性 | 测试词 |
+|---|---|---|---:|---|---|
+| `2026-07-24T13-53-48p08-00.json` | `ModalWebViewWidget - search:search-command-bar:default` | 空 | 2 | true | 缺失 |
+| `2026-07-24T13-53-52p08-00.json` | `飞书` | `AXGroup` | 0 | true | 缺失 |
+| `2026-07-24T13-54-08p08-00.json` | `ModalWebViewWidget - search:search-command-bar:default` | 空 | 2 | true | 缺失 |
+| `2026-07-24T13-54-37p08-00.json` | `ModalWebViewWidget - search:search-command-bar:default` | 空 | 2 | true | 缺失 |
+
+结构检查：
+
+- 搜索弹窗 focused window 能正确识别。
+- 弹窗 AX Tree 只有 6 个嵌套 `AXGroup`，最大深度为 5。
+- 没有 `AXTextField`、`AXTextArea`、`AXComboBox` 或文本 value。
+- app 级 `kAXFocusedUIElementAttribute` 在弹窗中返回空。
+- 主窗口偶尔返回真实 focused element，但角色仅为 `AXGroup`。
+- watcher 点击目标只到 `AXScrollArea`，没有搜索输入框标识。
+
+因此本次失败不是 S1 parser 错选节点：当前飞书搜索弹窗没有通过所抓取的
+macOS AX 接口暴露输入控件或搜索文字。继续递归也无法恢复不存在的节点。
+后续需要单独评估 Electron renderer accessibility、飞书特定适配，或
+OCR/视觉 fallback；在无法可靠确认输入目标时继续返回空，避免猜测。
+
+## VS Code 编辑器：未通过
+
+测试标记：
+
+```text
+OC_VSCODE_EDITOR_001
+EDITOR_FOCUS_001
+```
+
+测试产生 14 个 VS Code capture。窗口标题能跟随 Untitled 文档变化，但
+编辑器正文和真实焦点没有通过 AX Tree 暴露。
+
+关键证据：
+
+| Capture 文件 | Trigger | 窗口标题 | Focused element | Retry | 一致性 |
+|---|---|---|---|---:|---|
+| `2026-07-24T13-56-38p08-00.json` | `AXValueChanged` | 含第一个测试标记 | 空 | 0 | true |
+| `2026-07-24T13-57-16p08-00.json` | `AXValueChanged` | 含第一个测试标记 | 空 | 0 | true |
+| `2026-07-24T13-57-59p08-00.json` | `AXApplicationActivated` | 含第一个测试标记 | 空 | 2 | true |
+| `2026-07-24T13-58-15p08-00.json` | `AXApplicationActivated` | 含第一个测试标记 | 空 | 2 | true |
+
+结构检查：
+
+- focused window 能正确识别，标题稳定来自 `ax_snapshot`。
+- app 级 `kAXFocusedUIElementAttribute` 返回空。
+- 编辑窗口 AX Tree 只有 7 个嵌套 `AXGroup`，最大深度为 6。
+- 没有 `AXTextArea`、`AXTextField`、`AXWebArea` 或编辑器文本 value。
+- 第一个测试标记只出现在窗口标题，不存在于任何 AX element。
+- 第二个测试标记没有出现在 focused value 或 visible text。
+- 短暂出现的 `AXSheet` 焦点属于警告弹窗，不是编辑器。
+
+因此不能把“窗口标题包含首行文字”视为正文读取成功。该结果与飞书搜索弹窗
+相似，表明两个 Electron 应用可能共享 renderer accessibility 未启用的问题。
+应先调查如何可靠启用 Electron/Chromium AX renderer，再考虑 parser fallback。
+
+## Electron AX renderer 适配
+
+根据 Electron 官方的第三方 macOS accessibility 接入方式，Swift helper
+现在会在抓取 allowlist 中的 Electron 应用之前，对 application AX element
+设置：
+
+```text
+AXManualAccessibility = true
+```
+
+默认配置：
+
+```toml
+[capture]
+enable_electron_accessibility = true
+electron_accessibility_bundles = [
+  "com.microsoft.VSCode"
+]
+```
+
+实现约束：
+
+- 只对显式 bundle allowlist 生效，不影响其他应用。
+- 在读取 focused element、focused window 和 renderer tree 之前设置属性。
+- 现有 150 ms / 350 ms 有限重试用于等待 renderer AX tree 初始化。
+- helper 在 app JSON 中记录 requested、succeeded 和 AX error code。
+- Python provider 将结果提升到 `ax_metadata.manual_accessibility`，便于审计。
+- 配置可整体关闭，也可替换 bundle allowlist。
+
+验证结果：
+
+```text
+mac-ax-helper: compiled successfully
+115 passed in 1.91s
+changed-file Ruff checks: passed
+git diff --check: passed
+```
+
+下一步需要在带有 Terminal 辅助功能权限的隔离 daemon 中重新测试飞书和
+VS Code，确认 renderer tree 是否从纯 `AXGroup` 展开为可用的输入控件和文本。
+
+### VS Code Electron 复验：通过
+
+`AXManualAccessibility` 设置结果：
+
+```json
+{
+  "bundle_id": "com.microsoft.VSCode",
+  "requested": true,
+  "succeeded": true,
+  "error_code": 0
+}
+```
+
+启用前后结构对比：
+
+| 状态 | 节点数 | 最大深度 | 关键角色 |
+|---|---:|---:|---|
+| 启用前 | 7 | 6 | 仅 `AXGroup` |
+| 启用后 | 约 177 | 30 | `AXWebArea`、`AXTextArea`、Toolbar、Button、StaticText 等 |
+
+关键证据：
+
+| Capture 文件 | Trigger | 焦点 | 可编辑 | 测试正文 | 一致性 |
+|---|---|---|---|---|---|
+| `2026-07-24T14-42-37p08-00.json` | `AXValueChanged` | 空 | false | renderer tree 已展开 | true |
+| `2026-07-24T14-42-44p08-00.json` | `UserMouseClick` | `AXTextArea` | true | 编辑器已识别 | true |
+| `2026-07-24T14-43-42p08-00.json` | `AXValueChanged` | `AXTextArea` | true | focus 标记存在 | true |
+| `2026-07-24T14-43-51p08-00.json` | `AXApplicationActivated` | `AXTextArea` | true | focus 标记存在 | true |
+| `2026-07-24T14-44-06p08-00.json` | `AXApplicationActivated` | `AXTextArea` | true | focus 标记存在 | true |
+
+成功样本中 focused value 长度为 66，测试标记同时进入 focused value 和
+visible text。VS Code 原验收项“编辑区不再返回空或标题文字”通过。
+
+### 飞书 Electron 复验：仍未通过
+
+`AXManualAccessibility` 设置结果：
+
+```json
+{
+  "bundle_id": "com.electron.lark",
+  "requested": true,
+  "succeeded": false,
+  "error_code": -25205
+}
+```
+
+macOS AX error `-25205` 表示 attribute unsupported。飞书主 application AX
+element 不接受 `AXManualAccessibility`，因此 renderer tree 没有展开：
+
+- 主窗口仍只有有限的 Group/Button/Unknown 等节点。
+- 搜索弹窗仍只有 6 个嵌套 `AXGroup`。
+- 搜索输入框、测试词和真实 focused element 均缺失。
+- 两次有限重试无法改变结构。
+
+结论：通用 Electron 适配对 VS Code 有效，但飞书的定制 Electron/多进程
+实现不支持该 application-level 属性。飞书需要独立调查子进程 AX、应用自身
+accessibility 开关或视觉/OCR fallback，不能继续通过 parser 猜测。
+
+### 最终范围决定
+
+本轮不继续实现飞书专用子进程 AX 适配，也暂不实现 OCR。原因如下：
+
+- 飞书使用定制 Lark Framework 和多个 renderer 子进程。
+- 主 application AX element 明确返回 attribute unsupported。
+- 按 renderer PID 做映射会绑定飞书私有进程结构，版本升级后容易失效。
+- 该方案只能服务单个应用，维护成本高、泛化价值低。
+
+因此默认 Electron allowlist 已移除 `com.electron.lark`，避免每次飞书 capture
+重复执行必然失败的属性设置。当前默认只保留已经现场验证成功的：
+
+```toml
+electron_accessibility_bundles = ["com.microsoft.VSCode"]
+```
+
+飞书继续使用现有 AX 结果；无法可靠确定搜索框时 `focused_element` 保持空，
+不从 `AXGroup` 猜测输入控件。OCR/视觉 fallback 作为后续独立设计事项，
+不属于本轮修复范围。
+
+## Terminal：通过
+
+测试标记：
+
+```text
+OC_TERMINAL_INPUT_001
+OC_TERMINAL_FOCUS_001
+```
+
+测试产生 13 个 Terminal capture。真实焦点、输入内容、窗口标题和应用一致性
+均符合预期。
+
+关键证据：
+
+| Capture 文件 | Trigger | 焦点 | 测试标记 | Retry | 一致性 |
+|---|---|---|---|---:|---|
+| `2026-07-24T14-00-56p08-00.json` | `AXValueChanged` | `AXTextArea` | 第一个标记 | 0 | true |
+| `2026-07-24T14-01-17p08-00.json` | `AXValueChanged` | `AXTextArea` | 第一个标记 | 0 | true |
+| `2026-07-24T14-01-39p08-00.json` | `AXValueChanged` | `AXTextArea` | 两个标记 | 0 | true |
+| `2026-07-24T14-01-51p08-00.json` | `UserMouseClick` | `AXTextArea` | 两个标记 | 0 | true |
+| `2026-07-24T14-02-03p08-00.json` | `AXApplicationActivated` | `AXTextArea` | 两个标记 | 0 | true |
+
+所有有效样本：
+
+- `focused_element.role = AXTextArea`
+- `focused_element.is_editable = true`
+- 测试标记同时存在于 focused value 和 visible text
+- `title_source = ax_snapshot`
+- `retry_count = 0`
+- `app_consistent = true`
+- watcher 点击目标正确保留 `role = AXTextArea`
+
+最后连续点击未产生三份额外 Terminal capture。该原生 macOS AX 应用的通过
+结果进一步表明，飞书和 VS Code 的失败集中在 Electron renderer AX 暴露，
+而不是通用 focused-element parser。
+
+## 证据保留说明
+
+原始 capture JSON 和截图当前仍位于：
+
+```text
+/private/tmp/openchronicle-capture-test/capture-buffer
+```
+
+该目录可能在系统重启后消失，并且包含测试期间其他应用的本地截图与可见文字，
+不应直接提交到 Git 或发送给他人。对外汇报建议使用本报告中的脱敏字段摘要；
+如确需原始证据，应只导出上述表格列出的 TextEdit JSON，并先删除 screenshot
+及与结论无关的可见内容。

--- a/docs/user-enter-signal-implementation-report.md
+++ b/docs/user-enter-signal-implementation-report.md
@@ -1,0 +1,298 @@
+# OpenChronicle UserEnter Signal 实现汇报
+
+日期：2026-07-26
+
+## 1. 背景与目标
+
+本次工作为 OpenChronicle 增加物理 Enter 键 Signal，使系统能够在不把 Enter
+直接解释成“发送、提交或执行”的前提下，获得一个可靠的用户交互时间锚点。
+
+OpenChronicle 仍保持 AX-first：
+
+- Enter 是 AX 状态提取的触发器和时间边界；
+- AX Tree、focused element、URL 和 visible text 是主要结果证据；
+- Screenshot 继续沿用原有 Capture 配置和去重逻辑，只作为辅助信息；
+- Enter Signal 独立于 Snapshot 存储，Capture 失败不能导致 Signal 丢失。
+
+## 2. 设计思路
+
+### 2.1 Signal 与 Snapshot 分离
+
+新的数据流为：
+
+```text
+物理 Enter
+  → Swift watcher 捕获按键时的应用和安全 AX target
+  → 如有待输出文字，先输出 UserTextInput(reason=enter)
+  → 输出 UserEnter（与 UserTextInput 共用 signal_id）
+  → Python 隐私清洗
+  → signal-buffer 原子、幂等落盘
+  → T+200ms 请求正常 AX-first Capture
+  → T+1000ms 进行一次受限 follow-up，覆盖 800ms 后才更新的页面
+  → 新 Snapshot / 复用旧 Snapshot / 失败或跨应用状态回写
+```
+
+Signal 文件位于：
+
+```text
+~/.openchronicle/signal-buffer/<signal_id>.json
+```
+
+Snapshot 仍位于：
+
+```text
+~/.openchronicle/capture-buffer/<snapshot_id>.json
+```
+
+### 2.2 Enter 的语义边界
+
+所有 Enter 仅代表物理按键事件：
+
+```json
+{
+  "event_type": "UserEnter",
+  "semantic_intent": "unknown"
+}
+```
+
+系统不直接生成 `send`、`submit`、`execute` 等语义。聊天发送、Terminal
+执行、网页提交以及中文输入法候选确认，需要由后续上下文判断，不能只凭 Enter
+推断。
+
+### 2.3 按键时 target 与按键后 Snapshot 分离
+
+- `input_target` 在 keyDown 时立即读取，回答“Enter 发生在哪里”；
+- `snapshot_ref` 指向 Enter 后的 AX-first Capture，回答“界面之后是什么状态”；
+- 后续焦点变化不能覆盖 `input_target`；
+- 后续 Snapshot bundle 与按键时 bundle 不一致时，不进行关联。
+
+### 2.4 隐私前置与字段白名单
+
+UserEnter Signal 只允许保存：
+
+- `timestamp`
+- `pid`
+- `app_name`
+- `bundle_id`
+- `key_variant`
+- `modifiers`
+- `input_target.role`
+- `input_target.subrole`
+- `input_target.identifier`
+- `input_target_status`
+- `semantic_intent`
+- Snapshot 关联状态
+
+以下内容不会进入 Signal：
+
+- element `value`
+- element `title`
+- 用户输入原文
+- 输入法候选词
+- 默认窗口标题
+- URL
+- Screenshot
+- 推断出的发送、提交或执行语义
+
+`signal_id` 还经过安全字符校验，避免被用于构造越界文件路径。配置项
+`excluded_signal_bundle_ids` 可以在写入和日志记录之前完全排除指定应用。
+
+## 3. 代码修改
+
+### 3.1 Swift watcher
+
+文件：`resources/mac-ax-watcher.swift`
+
+- 识别普通 Return（keyCode 36）；
+- 识别小键盘 Enter（keyCode 76），统一输出 `UserEnter`；
+- Enter 检测位于 Command/Control 快捷键过滤之前；
+- 支持 Shift、Command、Control、Option 修饰键；
+- 过滤 `.keyboardEventAutorepeat`；
+- keyDown 时立即读取 frontmost app 和 focused AX element；
+- Signal target 使用结构字段专用白名单，不读取 title/value；
+- Enter 前调用 `flushText(reason: "enter", associationID: signalID)`；
+- 无待 flush 文本时不产生空 `UserTextInput`；
+- `UserTextInput` 和 `UserEnter` 共用同一个 `signal_id`；
+- 增加 `--self-test`，覆盖 Return、小键盘 Enter、普通字符、auto-repeat 和修饰键。
+
+### 3.2 SignalStore
+
+文件：`src/openchronicle/capture/signal_store.py`
+
+- 新增 UserEnter 隐私清洗；
+- 新增严格字段 allowlist；
+- 新增 excluded bundle 过滤；
+- 使用 `signal_id` 作为幂等键；
+- 使用临时文件加原子 replace 落盘；
+- 支持 Snapshot 状态和 `snapshot_ref` 回写；
+- Snapshot 状态使用优先级，避免后续失败覆盖已成功关联的 Snapshot；
+- 日志只输出 Signal ID、事件类型、bundle 和状态。
+
+### 3.3 路径与配置
+
+文件：
+
+- `src/openchronicle/paths.py`
+- `src/openchronicle/config.py`
+
+改动：
+
+- 新增 `signal_buffer_dir()`；
+- `ensure_dirs()` 自动创建 `signal-buffer`；
+- 新增 `excluded_signal_bundle_ids` 配置。
+
+### 3.4 Python dispatcher
+
+文件：`src/openchronicle/capture/event_dispatcher.py`
+
+- UserEnter 使用专用处理路径；
+- UserEnter 绕过普通 1 秒事件去重和 5 秒同窗口事件去重；
+- Signal 必须先成功写入，之后才能请求 Capture；
+- 相同 `signal_id` 的重复 watcher event 不会重复写入或重复触发 Capture；
+- 初始 Capture 延迟约 200ms；
+- follow-up Capture 在约 1 秒执行，以覆盖 T+800ms 的页面更新；
+- `UserTextInput` 的关联 ID 继续传递到 Snapshot trigger；
+- shutdown 会取消尚未执行的 Enter timer。
+
+### 3.5 Capture runner
+
+文件：`src/openchronicle/capture/scheduler.py`
+
+- 将 `UserEnter` 加入 `_AX_RETRY_EVENTS`；
+- 保留原有 150ms、350ms AX 完整性重试；
+- Capture fingerprint 和 Snapshot 去重继续启用；
+- 内容相同时向 Signal 回写已有 `snapshot_ref`；
+- 内容变化时回写新 Snapshot；
+- bundle 改变时记录 `app_changed`，不关联错误 Snapshot；
+- AX/Capture 失败、暂停、队列拥堵时回写失败状态，但 Signal 保留；
+- Capture 文件时间戳增加毫秒，避免同一秒内文件名冲突。
+
+### 3.6 自动化测试
+
+文件：
+
+- `tests/test_signal_store.py`
+- `tests/test_event_dispatcher.py`
+- `tests/test_capture_metadata.py`
+
+新增覆盖：
+
+- Signal 字段白名单；
+- element value/title、窗口标题和推断语义清除；
+- secure target 清除；
+- excluded bundle；
+- 不安全 signal ID 拒绝；
+- signal ID 幂等；
+- UserEnter 绕过事件去重；
+- UserTextInput/Enter 关联 ID；
+- 800ms 后更新的 follow-up 升级；
+- 相同 Snapshot 复用；
+- 应用切换后拒绝错误关联。
+
+## 4. 测试结果
+
+### 4.1 自动化与编译
+
+```text
+Python full suite: 127 passed
+Ruff: All checks passed
+git diff --check: passed
+Swift watcher build: passed
+Swift Enter self-tests: passed
+```
+
+Swift 自测覆盖：
+
+- Return keyCode 36；
+- keypad Enter keyCode 76；
+- 普通字符不产生 UserEnter；
+- Return/keypad Enter auto-repeat 被过滤；
+- Shift/Command/Control/Option 修饰键顺序与内容正确。
+
+### 4.2 TextEdit
+
+- 普通 Return 成功生成 UserEnter；
+- `input_target` 为安全的 `AXTextArea / First Text View`；
+- 有待输入文本时，`UserTextInput(reason=enter)` 与 UserEnter 共用 signal ID；
+- 无待输入文本时不生成空 UserTextInput；
+- Shift、Command、Control、Option 分别记录正确；
+- 长按 Return 只保留第一条 Signal；
+- 同画面多次 Enter 复用相同 Snapshot。
+
+### 4.3 Terminal
+
+- Enter 成功记录；
+- target 为安全的 `AXTextArea`；
+- `semantic_intent=unknown`，未标记为执行；
+- 测试命令文本没有进入 signal-buffer。
+
+### 4.4 Chrome
+
+- 地址栏 Enter 的 target 为 `AXTextField`；
+- 跳转后的 URL 由 AX Snapshot 获取，Signal 本身不保存 URL；
+- 本地测试页在 Enter 后 800ms 更新标题；
+- 初始观察复用旧 Snapshot，1 秒 follow-up 捕获更新结果并升级 `snapshot_ref`；
+- Chrome 页面无法提供 focused element 时，Signal 保留且记录 `ax_unavailable`。
+
+### 4.5 密码框
+
+使用唯一测试标记检查：
+
+- signal-buffer 中不存在密码文本；
+- capture-buffer 的 AX/文本 JSON 中不存在密码文本；
+- capture 日志和错误信息中不存在密码文本；
+- Signal 只保留 `AXTextField` 等结构字段；
+- 即使 Chrome 没有可靠暴露 secure subrole，字段白名单仍阻止 value 泄露。
+
+### 4.6 中文输入法
+
+- 使用 Return 确认候选词时生成一个物理 UserEnter；
+- `semantic_intent=unknown`；
+- 没有生成发送、提交或执行语义；
+- AX target 不可用时正确记录降级状态。
+
+### 4.7 飞书和 VS Code
+
+- 飞书无法提供可靠 target 时记录 `ax_unavailable`，Signal 不丢失；
+- VS Code 提供 `AXTextArea` target；
+- 快速执行“Enter → 切换应用”时，Signal 保持关联切换前的 VS Code Snapshot；
+- 后续飞书激活没有覆盖该关联，观察到的错误跨应用关联数为 0。
+
+### 4.8 20 次 Enter 压力测试
+
+测试结果：
+
+```text
+物理 Enter：20
+新增 Signal：20
+唯一 signal_id：20
+Signal 丢失：0
+唯一 Snapshot ref：3
+```
+
+最终状态包括：
+
+- 9 条复用 Snapshot；
+- 3 条生成新 Snapshot；
+- 3 条在随后切换应用后记录 `app_changed`；
+- 5 条在 Capture 队列拥堵时记录 `queue_full`。
+
+即使 Capture 队列拥堵，20 条 Signal 仍全部保留；同时没有为了 20 次 Enter
+保存 20 份重复截图。
+
+## 5. 最终结论
+
+UserEnter 已作为独立、可靠、隐私最小化的物理交互 Signal 接入
+OpenChronicle。实现保持 AX-first：Enter 用于切分输入和触发 AX 状态观察，
+Snapshot 继续使用原有内容去重，Screenshot 没有成为 Signal 的必要条件。
+
+Signal 与 Snapshot 的生命周期已经解耦，因此 AX 不可用、Screenshot 失败、
+Capture 队列拥堵、内容重复或应用切换都不会导致 Enter 丢失，也不会产生错误的
+跨应用关联。
+
+## 6. 当前边界
+
+- 没有数字小键盘硬件，因此 keypad Enter 使用 watcher 纯函数自测验证；
+- signal-buffer 的长期清理/保留周期尚未单独产品化，目前与测试记录一起保留在本地；
+- 测试使用 capture-only 模式，未让测试输入进入 timeline、writer 或 LLM 流程；
+- 测试结束后临时 localhost 页面和 OpenChronicle capture-only daemon 均已关闭。

--- a/docs/user-enter-signal-v2-implementation-report.md
+++ b/docs/user-enter-signal-v2-implementation-report.md
@@ -1,0 +1,696 @@
+# OpenChronicle UserEnter Signal V2 修改汇报
+
+日期：2026-07-27
+
+## 1. 修改背景
+
+第一轮已经完成物理 Enter Signal 的基础接入：
+
+- 普通 Return 和小键盘 Enter 均输出 `UserEnter`；
+- Enter Signal 与 Snapshot 分开持久化；
+- Signal 不受普通事件和 Snapshot 去重影响；
+- Enter 后执行 AX-first Capture；
+- Capture 失败、队列拥堵或应用切换时，Signal仍然保留；
+- Signal 使用隐私字段白名单，不保存输入原文和 element value；
+- 自动化、Swift 编译和多应用手动测试均已通过。
+
+第一轮证明了 UserEnter 可以被可靠捕获，但第二轮 Review 指出了长期运行场景中的
+数据建模、Capture 调度、并发一致性、隐私时序、shutdown 恢复和 Schema 演进问题。
+
+本轮修改目标是：
+
+> 每次有效物理 Enter 必须产生且只产生一条独立、持久化、不可重复的 Signal；
+> Capture 可以合并、复用、延迟或明确失败，但不能导致 Signal 丢失、状态倒退、
+> 隐私泄露或跨应用、跨窗口错误关联。
+
+## 2. 本轮修改范围
+
+本轮修改文件：
+
+- `resources/mac-ax-watcher.swift`
+- `resources/mac-ax-helper.swift`
+- `src/openchronicle/capture/signal_store.py`
+- `src/openchronicle/capture/event_dispatcher.py`
+- `src/openchronicle/capture/scheduler.py`
+- `src/openchronicle/capture/watcher.py`
+- `src/openchronicle/paths.py`
+- `tests/test_signal_store.py`
+- `tests/test_event_dispatcher.py`
+- `tests/test_capture_metadata.py`
+
+未修改或纳入本轮工作的已有文件：
+
+- `src/openchronicle/cli.py`
+- `docs/background-silent-run-guide.md`
+- `docs/troubleshooting-swift-bridging.md`
+
+## 3. 八项修改完成情况
+
+### 3.1 修正 ID 模型
+
+#### 第一轮问题
+
+第一轮让 `UserTextInput` 和 `UserEnter` 共用 `signal_id`。这样可以建立关联，
+但同一个 ID 同时代表两个不同对象，容易在持久化、去重、索引和重放时产生主键
+语义歧义。
+
+#### V2 实现
+
+现在每类对象拥有独立主键：
+
+| 对象 | 主键 |
+|---|---|
+| UserEnter | `signal_id` |
+| UserTextInput | `event_id` |
+| Capture Group | `capture_request_id` |
+| Capture Attempt | `attempt_id` |
+| Snapshot | Snapshot 文件 ID |
+
+`UserTextInput` 和 `UserEnter` 通过以下字段关联：
+
+```text
+UserTextInput.correlation_id
+UserEnter.correlation_id
+UserTextInput.related_signal_id → UserEnter.signal_id
+```
+
+Swift watcher 在收到 Enter 时：
+
+1. 生成新的 `signal_id`；
+2. 生成新的 `correlation_id`；
+3. 如有待输出文字，先生成带独立 `event_id` 的 `UserTextInput`；
+4. `UserTextInput.related_signal_id` 指向即将输出的 `UserEnter`；
+5. 再输出 `UserEnter`。
+
+无待输出文字时，仍然只产生 `UserEnter`，不产生空的 `UserTextInput`。
+
+#### 解决的问题
+
+- 不同持久化对象不再共用主键；
+- watcher event 重放可以按对象主键独立幂等；
+- Capture Group 和多个 Signal 可以建立多对一关系；
+- 后续索引、查询和 Schema 演进具有明确对象边界。
+
+### 3.2 固定 follow-up 改成条件式 Capture
+
+#### 第一轮问题
+
+第一轮对每次 Enter 固定执行：
+
+```text
+T+200ms primary Capture
+T+1000ms follow-up Capture
+```
+
+该设计可以覆盖 800ms 后才更新的页面，但即使 primary 已取得高质量新 Snapshot，
+follow-up 仍可能继续执行。第一轮 20 次 Enter 压力测试出现了 5 条最终
+`queue_full`，说明固定双 Capture 会放大请求量。
+
+#### V2 实现
+
+T+200ms 的 primary 保留，follow-up 根据结果决定：
+
+- primary 为 `new` 且 `quality_status=good`：
+  - 结果已经明确；
+  - 不再执行 follow-up。
+- primary 为 `reused` 或 `unchanged`：
+  - 允许最多一次 follow-up。
+- primary 为 degraded：
+  - 只有错误原因位于显式可重试白名单时才 follow-up。
+- `privacy_blocked`、`app_changed`、`permission_denied`、`screen_locked`：
+  - 不执行 follow-up。
+
+当前可重试原因使用明确集合，不再根据任意 degraded 状态自动重试：
+
+```text
+ax_incomplete
+capture_unavailable
+duplicate_without_ref
+queue_full
+temporary_capture_error
+```
+
+#### 自然 AX 事件
+
+等待 follow-up 期间，同应用、同进程和同窗口的自然 `AXValueChanged` 可以提前触发
+一次 `natural_event` Capture。
+
+自然事件不会仅凭“事件出现”就完成 Signal：
+
+1. 验证候选 Capture Group；
+2. 执行真实 Capture；
+3. Capture 成功后完成关联；
+4. Capture 失败或仍可重试时，恢复 follow-up 机会。
+
+#### 解决的问题
+
+- 高质量 primary 不再产生无价值的重复 Capture；
+- 慢页面仍然拥有第二次观察机会；
+- 自然 AX 变化可以减少固定等待；
+- 队列压力和 `queue_full` 风险降低；
+- 不可重试或隐私阻止场景不会继续采集。
+
+### 3.3 Capture Group 与多 Signal 回写
+
+#### 第一轮问题
+
+同一窗口快速按五次 Enter 时，第一轮可能安排五次 primary 和五次 follow-up。
+物理 Enter 不能合并，但重复 AX/Screenshot Capture 可以合并。
+
+#### V2 实现
+
+增加 `_CaptureGroup`，包含：
+
+```text
+capture_request_id
+bundle_id
+pid
+window_identity
+window_identity_confidence
+member_signal_ids
+created_at
+due_at
+phase
+attempt_id
+running
+```
+
+调度规则：
+
+- 每次有效 Enter 仍然创建独立 Signal；
+- 同应用、同进程和同窗口的 Enter 可以加入同一个等待执行的 Group；
+- 同一窗口最多一个运行中 Group和一个等待 Group；
+- Capture 开始时冻结本次 `member_signal_ids`；
+- Capture 开始后到达的新 Enter 进入等待 Group；
+- 新成员不会反复延长正在执行 Group 的 `due_at`；
+- Group 完成后，将同一个结果分别回写给所有成员；
+- 多成员结果使用 `association_mode=coalesced`；
+- 每个成员仍保留独立 `signal_id` 和 attempt ledger。
+
+自动化测试已验证：
+
+```text
+同窗口快速输入 5 个 UserEnter
+→ 5 个独立 Signal 文件
+→ 1 次共享 Capture 请求
+→ 5 个成员均获得相同 result_snapshot_ref
+→ association_mode=coalesced
+```
+
+`queue_full` 不再直接作为普通最终状态。primary 阶段队列拥堵先进入
+`deferred_queue_full`，后续机会用尽后再转成 `unresolved`。
+
+#### 解决的问题
+
+- 高频 Enter 不再线性放大 Capture 请求；
+- 保留物理事件数量准确性；
+- 多 Signal 可以共享相同界面证据；
+- Capture 合并不影响每条 Signal 的独立身份和状态。
+
+### 3.4 区分按键前 Context 和按键后 Result
+
+#### 第一轮问题
+
+第一轮只有一个 `snapshot_ref`，无法区分：
+
+- Enter 前最近一次 Snapshot；
+- Enter 后内容相同，因此复用旧 Snapshot；
+- Enter 后真正产生的新 Snapshot。
+
+应用切换时，切换前 Snapshot 还可能被误读成 Enter 后结果。
+
+#### V2 实现
+
+Signal V2 拆分为：
+
+```text
+context_snapshot_ref
+result_snapshot_ref
+post_capture_status
+quality_status
+capture_attempts
+```
+
+`context_snapshot_ref` 在 Enter 进入 dispatcher 时冻结，只复用当前已知的同应用
+Snapshot。
+
+结果语义：
+
+```text
+Enter 前 A，Enter 后变化为 B
+→ context=A, result=B, status=new
+
+Enter 前 A，Enter 后确认内容相同
+→ context=A, result=A, status=reused
+
+Enter 后应用或高置信度窗口发生变化
+→ context=A, result=null, status=app_changed
+```
+
+每次 Capture Attempt 记录：
+
+- `attempt_id`
+- `capture_request_id`
+- `phase`
+- `association_mode`
+- `requested_at`
+- `due_at`
+- `started_at`
+- `completed_at`
+- `bundle_id`
+- `window_identity`
+- `window_identity_confidence`
+- `status`
+- `snapshot_ref`
+- `quality_status`
+- `error_reason`
+
+支持的 phase：
+
+```text
+primary
+natural_event
+follow_up
+recovery
+```
+
+#### 窗口身份
+
+Swift watcher 和 AX helper 现在尝试读取 `AXWindowNumber`。
+
+高置信度身份：
+
+```text
+bundle_id + pid + AXWindowNumber
+```
+
+无法取得窗口编号时，使用：
+
+```text
+bundle_id + pid
+window_identity_confidence=low
+```
+
+高置信度窗口身份不一致时，Capture runner拒绝关联结果。
+
+#### 解决的问题
+
+- Enter 前证据和 Enter 后结果不再混淆；
+- `reused` 表示 Enter 后重新观察并确认内容相同；
+- 应用或窗口切换时不会把旧 Snapshot 描述成新结果；
+- 每次 Capture 的时间、质量和失败原因均可追踪。
+
+### 3.5 并发更新、Revision 和幂等
+
+#### 第一轮问题
+
+原子 replace 只能防止半截 JSON，不能防止两个异步任务同时读取旧对象并相互覆盖。
+
+例如：
+
+```text
+primary 读取 revision 1
+follow-up 读取 revision 1
+primary 写入成功 Snapshot
+follow-up 用旧对象写入 queue_full
+```
+
+最终文件虽然仍是合法 JSON，但 primary 的成功结果可能丢失。
+
+#### V2 实现
+
+##### Capture daemon singleton
+
+- 同一 OpenChronicle 数据根目录只允许一个 Capture daemon；
+- 使用 `fcntl.flock` 获取操作系统文件锁；
+- 第二个 daemon 无法获取锁时抛出明确的 `already_running`；
+- 进程崩溃或 `kill -9` 后，操作系统自动释放锁。
+
+锁文件：
+
+```text
+<OPENCHRONICLE_ROOT>/.capture-daemon.lock
+```
+
+##### SignalStore 串行更新
+
+- 每个 `signal_id` 使用独立 `RLock`；
+- 所有关联更新统一调用 `update_linkage()`；
+- 获得锁后重新读取磁盘最新对象；
+- 每次只合并本次更新字段；
+- 不使用 callback 前缓存的完整旧对象覆盖文件；
+- 每次有效更新执行 `revision + 1`；
+- `expected_revision` 不一致时基于最新 revision 合并；
+- 相同 `attempt_id` 重复提交时幂等更新，不重复追加；
+- Signal 核心字段在创建后不由 Capture 更新修改；
+- `new/reused/unchanged` 成功结果不能被后续失败、queue-full 或 shutdown 降级。
+
+##### Snapshot 文件名
+
+Snapshot 文件名由：
+
+```text
+毫秒时间戳 + UUID
+```
+
+组成，避免同一毫秒并发文件名冲突。
+
+#### 解决的问题
+
+- primary 成功不会被 follow-up 失败覆盖；
+- 两个 daemon 不会同时写同一数据目录；
+- callback 重放不会重复创建 attempt；
+- Signal JSON 始终可解析且 revision 可追踪；
+- Snapshot 文件不会因并发时间戳相同而覆盖。
+
+### 3.6 隐私策略前移
+
+#### 第一轮问题
+
+第一轮 excluded bundle 主要在 Python 侧过滤，但 Swift 在输出 `UserEnter` 前会先：
+
+```text
+flushText(reason="enter")
+```
+
+因此被排除应用的 `UserTextInput` 可能已经进入 stdout 和 dispatcher，之后 Python
+才丢弃 `UserEnter`。“Signal 没有落盘”不等于“文字从未进入采集链路”。
+
+#### V2 实现
+
+Python 配置继续作为唯一真实来源：
+
+```text
+excluded_signal_bundle_ids
+```
+
+启动 watcher 时，Python 将以下信息作为参数传给 Swift：
+
+- 排除 bundle 列表；
+- `privacy_policy_version`。
+
+Swift watcher：
+
+- 在 `flushText()` 前检查 bundle；
+- excluded app 不输出 `UserTextInput`；
+- excluded app 不输出 `UserEnter`；
+- 丢弃该应用待输出文本；
+- UserTextInput 和 UserEnter 均携带相同策略版本；
+- 缺少策略或版本不支持时以退出码 3 拒绝启动。
+
+Python dispatcher：
+
+- 对 `UserTextInput`、`UserEnter` 和其他后续 Capture 事件再次检查 bundle；
+- 即使 Swift 输出异常，Python 仍执行防御性阻止；
+- watcher 以退出码 3 结束时不进行不安全重启。
+
+`input_target.identifier` 新增：
+
+- 最大长度限制；
+- 控制字符拒绝；
+- 多行或疑似动态长内容清理。
+
+#### 解决的问题
+
+- excluded app 内容不会先离开 Swift 再被 Python 丢弃；
+- Swift 和 Python 使用同一隐私策略来源和版本；
+- 策略缺失时不会默认开放采集；
+- identifier 不再被默认视为完全安全的结构字段。
+
+### 3.7 Shutdown、重启和 Recovery
+
+#### 第一轮问题
+
+第一轮 shutdown 会取消尚未运行的 Enter timer：
+
+```text
+Enter 已持久化
+→ 100ms 后 shutdown
+→ T+200ms primary 被取消
+→ Signal 可能永久保持 pending
+```
+
+#### V2 实现
+
+shutdown 使用 producer → consumer 顺序：
+
+1. 停止 watcher，不再产生新事件；
+2. dispatcher 进入 draining；
+3. 取消尚未执行的 Enter timer；
+4. 将未完成 Signal 标记为 `deferred_shutdown`；
+5. 追加 `cancelled_shutdown` attempt；
+6. Capture worker排空已经进入队列的任务。
+
+如果 primary 已成功而 follow-up 尚未开始：
+
+- 保留 `result_snapshot_ref`；
+- 保留成功状态；
+- shutdown 不得将成功结果降级。
+
+#### 启动恢复
+
+在启动 watcher 前：
+
+1. 扫描 signal-buffer；
+2. 检查或迁移 Schema；
+3. 查找 `pending/running/deferred_queue_full/deferred_shutdown`；
+4. 旧 `running` 追加 `abandoned_process_exit`；
+5. 已有可信结果时不再补采；
+6. 未超时且窗口身份为高置信度时，允许一次 recovery Capture；
+7. 超时转成 `unresolved/recovery_expired`；
+8. 窗口身份无法可靠确认时转成 `unresolved/context_changed`。
+
+Recovery 使用独立：
+
+```text
+phase=recovery
+association_mode=recovery
+attempt_id
+```
+
+#### 解决的问题
+
+- shutdown 后不再留下无解释的永久 pending；
+- DRAINING 前已经进入 dispatcher 的 Enter 仍然保留；
+- 成功 primary 不会因取消 follow-up 而倒退；
+- 进程异常退出后，旧 running 有明确处理路径；
+- 无法证明上下文一致时宁可 unresolved，不进行错误补采。
+
+### 3.8 Schema 版本和状态机
+
+#### V2 Schema
+
+新增版本字段：
+
+```text
+signal_schema_version = 2
+capture_schema_version = 2
+privacy_policy_version = 1
+```
+
+版本常量由存储层统一写入，调用方不自行声明。
+
+#### V1 迁移
+
+第一轮明确带有：
+
+```text
+schema_version = 1
+```
+
+的 UserEnter Signal 支持原子、幂等迁移到 V2。
+
+迁移规则：
+
+- 旧 `snapshot_status=captured` → `post_capture_status=new`
+- 旧 `snapshot_status=reused` → `post_capture_status=reused`
+- 旧 `snapshot_status=duplicate_without_ref` → `unchanged`
+- 旧 `snapshot_status=queue_full` → `deferred_queue_full`
+- 旧 `snapshot_status=app_changed` → `app_changed`
+- 无法从 V1 确认的 context 保持 null；
+- 不伪造不存在的历史 Capture Attempt；
+- 添加 `migrated_from_schema_version=1`；
+- 重复启动不会重复迁移。
+
+缺少版本的文件视为 legacy；未知或未来版本：
+
+- 不修改；
+- 不降级；
+- 不触发 Recovery Capture；
+- 输出 `unsupported_schema` 诊断。
+
+#### 状态拆分
+
+证据质量：
+
+```text
+quality_status = good | degraded | failed
+```
+
+Enter 后结果：
+
+```text
+post_capture_status
+```
+
+成功终态：
+
+```text
+new
+reused
+unchanged
+```
+
+非终态：
+
+```text
+pending
+running
+deferred_queue_full
+deferred_shutdown
+```
+
+明确终态：
+
+```text
+unresolved
+app_changed
+privacy_blocked
+```
+
+状态规则：
+
+- 成功终态不能被失败或 shutdown 降级；
+- 非法状态转换被拒绝并记录；
+- follow-up 和 recovery 机会结束后，deferred 状态转成成功或 unresolved；
+- quality 与业务关联状态不再混入同一个字段。
+
+## 4. 更新后的数据流
+
+```text
+物理 Enter
+  → Swift 检查 privacy policy
+  → 生成 signal_id + correlation_id
+  → 如有待输出文字：
+       UserTextInput(event_id, correlation_id, related_signal_id)
+  → UserEnter(signal_id, correlation_id)
+  → Python 再次检查 excluded bundle
+  → Signal V2 原子、幂等落盘
+  → 冻结 context_snapshot_ref
+  → 加入同窗口 Capture Group
+  → T+200ms primary
+       ├─ new + good → 完成，不 follow-up
+       ├─ reused/unchanged → 最多一次 follow-up
+       ├─ retryable degraded → 最多一次 follow-up
+       ├─ natural AX success → 提前完成
+       ├─ queue_full → deferred，保留后续机会
+       └─ app/privacy/window mismatch → 明确终态
+  → update_linkage() 对所有成员串行回写
+  → shutdown/restart 时执行 deferred/recovery 收敛
+```
+
+## 5. 自动化和编译结果
+
+最终验证结果：
+
+```text
+Python full suite: 139 passed
+Changed-file Ruff: All checks passed
+git diff --check: passed
+Swift mac-ax-watcher build: passed
+Swift Enter self-tests: passed
+Swift mac-ax-helper build: passed
+```
+
+本轮新增或更新的自动化覆盖：
+
+- V2 Signal Schema；
+- ID 和事件关联关系；
+- UserEnter 幂等；
+- UserTextInput 独立 event ID；
+- identifier 隐私清洗；
+- revision 严格递增；
+- stale update 基于最新对象合并；
+- attempt ID 幂等；
+- 成功状态不可降级；
+- 五 Signal 合并一次 Capture；
+- Capture Group 多成员结果回写；
+- high-quality primary 取消 follow-up；
+- reused primary 允许一次 follow-up；
+- context/result 字段；
+- 应用切换拒绝关联；
+- shutdown 转 `deferred_shutdown`；
+- singleton daemon lock；
+- V1 → V2 幂等迁移；
+- Snapshot UUID 文件名。
+- attempt 完成更新保留原请求时间；
+- UserTextInput 最小化 event-buffer 持久化；
+- Capture Group 最多一次 natural-event attempt；
+- excluded app Capture 前后双重检查；
+- excluded app 普通事件入队前静默拦截。
+
+## 6. 真实 macOS 手动验收
+
+真实 macOS 手动验收已经完成，详细证据和测试中发现的修复见：
+
+[`docs/user-enter-signal-v2-manual-test-report.md`](user-enter-signal-v2-manual-test-report.md)
+
+验收结论：
+
+- TextEdit 基础 ID/关联和 attempt ledger：通过；
+- UserTextInput 最小化独立持久化：通过；
+- 快速五次 Enter 与 Capture Group：通过；
+- 连续 20 次 Enter、无丢失、无 queue full：通过；
+- excluded app 事件、Signal、Capture、内容落盘均为 0：通过；
+- Secure Input Enter 抑制且测试秘密未落盘：通过；
+- singleton daemon lock：通过；
+- SIGTERM 优雅关闭、队列收敛、锁释放和同 root 重启：通过。
+
+限制：
+
+- 测试机器没有独立数字小键盘，未做真实 keypad Enter 手测；
+- 强制崩溃后的 incomplete recovery 仍主要由自动化测试覆盖；
+- `AXWindowNumber` 在不支持它的应用中继续使用低置信度 fallback。
+
+## 7. 当前工作区状态
+
+本轮 V2 修改尚未创建 commit，也未 push。
+
+当前分支：
+
+```text
+codex/capture-fixes-20260724
+```
+
+上一轮 UserEnter commit：
+
+```text
+1819e31 feat(capture): add durable UserEnter signals
+```
+
+建议在主管确认 V2 数据模型和功能对照后：
+
+1. 先执行真实 macOS 手动验收；
+2. 根据测试结果修正；
+3. 只暂存本轮 V2 文件；
+4. 创建独立 V2 commit；
+5. 再决定是否 push 或提交 PR。
+
+## 8. 总结
+
+第二轮已经将 UserEnter 从第一轮的“可靠物理信号 + 固定延迟 Capture”升级为：
+
+- 对象主键清晰；
+- Signal 与 Capture 生命周期解耦；
+- 条件式 Capture；
+- 多 Signal Capture Group；
+- Context/Result/Attempt 语义明确；
+- 并发更新可合并且幂等；
+- Swift/Python 双层隐私阻止；
+- shutdown 和启动恢复可收敛；
+- Schema 和状态机可版本化演进。
+
+当前自动化、编译检查和真实 macOS 核心行为验收均通过。测试过程中发现的
+attempt 合并、UserTextInput 持久化、natural-event 重复、excluded-app
+快照竞态和日志反馈循环均已修复并加入回归覆盖。下一步是整理本轮文件并创建独立
+V2 commit，交由主管 review。

--- a/docs/user-enter-signal-v2-manual-test-report.md
+++ b/docs/user-enter-signal-v2-manual-test-report.md
@@ -1,0 +1,335 @@
+# OpenChronicle UserEnter Signal V2 手动测试报告
+
+日期：2026-07-27
+
+平台：macOS
+
+分支：`codex/capture-fixes-20260724`
+
+测试模式：隔离 `OPENCHRONICLE_ROOT` + `--capture-only`
+
+## 1. 测试结论
+
+UserEnter Signal V2 的核心功能和第二轮修改要求已经通过真实 macOS
+手动验证。测试期间发现四类实现问题和一个测试方法问题；实现问题均已修复并复测，
+最终完整 Python 测试为 `139 passed`。
+
+最终结论：
+
+- UserEnter 与 UserTextInput 使用独立主键，并通过关联字段正确连接；
+- UserTextInput 有独立、最小化、可持久化的关系记录；
+- 条件式 Capture、自然 AX 触发和 Capture Group 工作正常；
+- 快速输入和连续 20 次 Enter 没有丢失 Signal；
+- excluded app 在事件、Signal、Capture 和落盘内容四个层面均被阻止；
+- Secure Input 中的 Enter 被抑制，测试秘密没有落盘；
+- 单实例锁、优雅关闭、队列收敛和同 root 重启均正常；
+- 所有检查结束后没有 `pending`、`running`、临时文件或 `queue_full` 遗留。
+
+## 2. 测试边界与方法
+
+为避免测试内容进入用户的正式 OpenChronicle 记忆，本轮使用多个
+`/tmp/openchronicle-user-enter-v2-run*` 隔离目录，并配置：
+
+```toml
+[capture]
+event_driven = true
+heartbeat_minutes = 0
+include_screenshot = true
+ax_depth = 100
+ax_timeout_seconds = 3
+debounce_seconds = 3
+min_capture_gap_seconds = 0
+dedup_interval_seconds = 0
+same_window_dedup_seconds = 0
+
+[reducer]
+enabled = false
+
+[mcp]
+auto_start = false
+```
+
+隐私排除测试额外配置：
+
+```toml
+excluded_signal_bundle_ids = ["com.apple.TextEdit"]
+```
+
+每组操作完成后直接检查：
+
+- `event-buffer/*.json`
+- `signal-buffer/*.json`
+- `capture-buffer/*.json`
+- `logs/capture.log`
+- `index.db`
+- 临时文件残留
+
+测试未运行 reducer、writer 或 MCP，避免测试文本进入长期记忆或模型流程。
+
+## 3. 功能测试结果
+
+### 3.1 TextEdit 基础关联
+
+操作：在 TextEdit 输入普通文本并按 Enter。
+
+结果：
+
+- UserTextInput 和 UserEnter 均生成；
+- `event_id` 与 `signal_id` 各自独立；
+- 两者的 `correlation_id` 相同；
+- `UserTextInput.related_signal_id` 精确指向 UserEnter；
+- UserTextInput 先于 UserEnter 持久化；
+- Capture attempt 能得到明确最终结果。
+
+结论：通过。
+
+### 3.2 Attempt 时间字段完整性
+
+首次测试发现：attempt 从 `running` 更新为完成状态时，
+`requested_at`、`due_at`、`started_at` 被空值覆盖。
+
+修复：
+
+- 合并已有 attempt 时忽略值为 `None` 的更新字段；
+- 增加 `test_attempt_completion_preserves_requested_timestamps`。
+
+复测结果：
+
+- primary 和 follow-up 的请求、计划、开始、结束时间均完整；
+- attempt ID 保持稳定；
+- 状态更新没有丢失前序字段。
+
+结论：修复后通过。
+
+### 3.3 UserTextInput 独立持久化
+
+首次测试发现：当关联 Capture 被内容去重时，UserTextInput 的独立关系证据没有持久化。
+
+修复：
+
+- 新增 `event-buffer`；
+- UserTextInput 在 Capture 前原子持久化；
+- 使用独立 `event_id`；
+- 重复 `event_id` 幂等，不重复触发 Capture；
+- 只允许关系字段和安全的 AX 结构字段落盘；
+- 不保存输入值、窗口标题或文本内容。
+
+复测结果：
+
+- event 文件数量正确；
+- ID 和关联关系正确；
+- event 中没有输入内容、value 或 title；
+- Capture 去重不影响事件关系证据。
+
+结论：修复后通过。
+
+### 3.4 快速五次 Enter 与 Capture Group
+
+操作：在同一窗口快速按五次 Enter。
+
+结果：
+
+- 五条独立 Signal；
+- 五个唯一 `signal_id`；
+- Signal 被合并到少量 Capture Group，而不是一键一张截图；
+- 所有 Group 成员均得到最终结果；
+- `pending=0`；
+- `queue_full=0`。
+
+首次测试还发现：同一 Capture Group 可能因重复 `AXValueChanged`
+执行多次 `natural_event` attempt。
+
+修复：
+
+- Group 新增 `natural_attempted` 状态；
+- 每个 Group 最多执行一次 natural-event Capture；
+- 增加并发回归测试。
+
+复测中五条 Signal 分为 `4+1` 两个 Group；第一组只有一次
+natural-event attempt，所有成员最终均为 `reused/good`。
+
+结论：修复后通过。
+
+### 3.5 连续 20 次 Enter 压力测试
+
+用户实际在约 5.2 秒内完成 20 次 Enter，比计划的每秒一次更激进。
+
+结果：
+
+- Signal：20；
+- 唯一 `signal_id`：20；
+- 丢失：0；
+- Capture Group：4 个，成员数为 `6+6+6+2`；
+- 最终 `reused/good`：20；
+- `pending=0`；
+- `queue_full=0`；
+- 每个 attempt 的时间字段完整；
+- 同一个物理 Capture 可被多个 Signal 安全复用。
+
+结论：通过。
+
+### 3.6 Excluded App
+
+目标应用：TextEdit。
+
+最终测试标记：`V2_EXCLUDED_RACE_FINAL_0727_K4M`。
+
+第一轮排除测试中，TextEdit 的 UserTextInput 和 UserEnter 已为 0，
+但来自其他应用的已排队事件可能在切换到 TextEdit 后执行，从而持久化 TextEdit 快照。
+
+第一项修复：
+
+- Capture 前读取当前前台应用；
+- AX Capture 后再次检查实际 Snapshot bundle；
+- 任一阶段命中排除策略即在截图和写盘前停止。
+
+复测后 TextEdit 快照为 0，但发现日志反馈循环：
+daemon 向 Terminal 写日志可产生 Terminal `AXValueChanged`，
+该事件在 TextEdit 为前台时进入 Capture，然后又记录“隐私跳过”日志。
+
+第二项修复：
+
+- 对没有 Signal 关联的普通事件，在进入 Capture 队列前检查当前前台应用；
+- 命中 excluded app 时静默丢弃；
+- Signal 关联请求仍允许进入 worker，以保证 attempt ledger 能够收敛。
+
+最终 run9 结果：
+
+- TextEdit UserTextInput：0；
+- TextEdit UserEnter：0；
+- TextEdit Capture/Snapshot：0；
+- 测试标记落盘：0；
+- 隐私跳过循环日志：0；
+- `queue_full`：0；
+- 临时文件：0。
+
+结论：修复后通过。
+
+### 3.7 Secure Input
+
+测试使用原生 AppleScript 隐藏输入框。
+
+第一次测试的密码框 Enter 已被正确抑制，但 `osascript` 默认把对话框结果输出到
+Terminal，导致测试标记随后以普通终端文本形式被正常 Capture。该结果属于测试工具
+回显，不是从 Secure Input 或键盘事件中读取，因此该轮隐私落盘结论作废。
+
+第二次使用：
+
+```bash
+osascript -e 'display dialog "OpenChronicle Secure Input Retest" default answer "" with hidden answer buttons {"Cancel", "OK"} default button "OK"' >/dev/null
+```
+
+最终测试标记：`V2_SECURE_NOREPLAY_0727_R6Y`。
+
+复测结果：
+
+- 执行命令时的普通 Terminal Enter 正常记录；
+- 密码框内的 Enter 没有生成 UserEnter；
+- 密码框内没有生成 UserTextInput；
+- 测试标记在事件、Signal、Capture、日志和 `index.db` 中均为 0；
+- `queue_full=0`。
+
+结论：通过。
+
+### 3.8 单实例锁
+
+在 run10 daemon 运行期间，用同一个 `OPENCHRONICLE_ROOT` 启动第二个 daemon。
+
+结果：
+
+```text
+Already running (pid 21942)
+```
+
+第二个进程立即退出，没有启动第二个 watcher。
+
+结论：通过。
+
+### 3.9 Shutdown、队列收敛与重启
+
+先说明一个测试操作差异：`openchronicle start` 默认后台运行，因此在 shell
+提示符处按 `Control-C` 不会停止 daemon。最终使用正式命令：
+
+```bash
+openchronicle stop
+```
+
+关闭时，执行 stop 命令本身产生了一条 Terminal UserEnter。该 Signal
+先进入 `deferred_shutdown`，随后已进入 worker 的 Capture 完成，
+最终收敛为 `reused`。
+
+关闭后结果：
+
+- `.pid` 文件删除；
+- Capture 日志停止增长；
+- 日志包含 `AX watcher stopped`；
+- 日志包含 `shutdown signal received` 和 `daemon stopped`；
+- session 以 `daemon-shutdown` 正常结束；
+- Signal 最终状态：`reused=8`、`new=2`；
+- `pending/running=0`；
+- 临时文件：0。
+
+随后使用同一个 root 重启：
+
+- 新 daemon PID：`23132`；
+- 新 watcher PID：`23133`；
+- 锁正常释放；
+- watcher 和启动 Capture 正常；
+- 历史 Signal 未被重复处理；
+- 重启后无 `pending/running/deferred_shutdown`。
+
+结论：通过。
+
+## 4. 自动化回归
+
+最终完整测试：
+
+```text
+139 passed in 2.46s
+```
+
+代码风格检查：
+
+```text
+Changed-file Ruff: All checks passed
+```
+
+测试环境因为工作区权限无法写 `.pytest_cache`，pytest 输出一个 cache warning；
+该 warning 不影响测试执行和结果。
+
+本轮手测过程中新增的关键回归覆盖：
+
+- attempt 完成更新保留 requested/due/started 时间；
+- UserTextInput 关系事件原子、最小化、幂等持久化；
+- Capture Group 最多一次 natural-event attempt；
+- Capture 时的前台 excluded-app 双重检查；
+- excluded app 普通事件在进入 Capture 队列前静默丢弃。
+
+## 5. 测试中发现并修复的问题
+
+| 问题 | 风险 | 修复结果 |
+|---|---|---|
+| attempt 完成时空值覆盖时间字段 | 审计链不完整 | 忽略空值覆盖并增加回归 |
+| UserTextInput 依赖 Capture 才有证据 | 去重后关联事件丢失 | 新增最小化 event-buffer |
+| Capture Group 重复 natural attempt | 多余 Capture 与不稳定 ledger | 每 Group 最多一次 |
+| 已排队事件跨入 excluded app | 排除应用快照可能落盘 | Capture 前后双重 bundle 检查 |
+| 隐私跳过日志触发 Terminal AX 反馈 | 重复无效 Capture 请求 | 入队前静默前台检查 |
+
+## 6. 未覆盖或需要持续观察的边界
+
+- 当前 Mac 没有独立数字小键盘，因此没有真实验证 keypad Enter；
+  Return 键及其 key variant 已验证，映射逻辑由 Swift self-test 覆盖。
+- 真实崩溃或 `SIGKILL` 后的 incomplete recovery 主要由自动化测试覆盖；
+  本轮真实系统测试覆盖的是 SIGTERM 优雅关闭、队列收敛、锁释放和同 root 重启。
+- 不同应用对 `AXWindowNumber` 的支持不一致，低置信度
+  `bundle_id:pid` fallback 仍需在后续真实使用中持续观察。
+
+## 7. 最终建议
+
+本轮修改已经达到提交主管 review 的条件。建议：
+
+1. 更新 V2 实现汇报中的测试状态；
+2. 只暂存 UserEnter V2 相关代码、测试和两份报告；
+3. 保留 `src/openchronicle/cli.py` 及其他无关文档修改，不混入本次 commit；
+4. 创建独立 V2 commit；
+5. 在主管确认后再 push 或创建 PR。

--- a/resources/mac-ax-helper.swift
+++ b/resources/mac-ax-helper.swift
@@ -357,6 +357,9 @@ func processWindow(_ window: AXUIElement, config: Config) -> [String: Any]? {
     var windowDict: [String: Any] = [
         "title": title,
     ]
+    if let windowNumber = axValue(window, "AXWindowNumber") as? NSNumber {
+        windowDict["window_number"] = windowNumber.int64Value
+    }
     if let subrole, !subrole.isEmpty { windowDict["subrole"] = subrole }
     if let description, !description.isEmpty { windowDict["description"] = description }
     if let identifier, !identifier.isEmpty { windowDict["identifier"] = identifier }

--- a/resources/mac-ax-helper.swift
+++ b/resources/mac-ax-helper.swift
@@ -32,6 +32,7 @@ struct Config {
     var maxDepth = 100   // 0 = unlimited
     var timeout: TimeInterval = 3
     var maxValueLength = 1000
+    var manualAccessibilityBundles: [String] = []
 }
 
 // MARK: - Filtered AX Node
@@ -372,12 +373,43 @@ func processApp(pid: pid_t, name: String, bundleID: String?, isFrontmost: Bool, 
 {
     let appRef = AXUIElementCreateApplication(pid)
 
+    var manualAccessibility: [String: Any]? = nil
+    if let bundle = bundleID,
+       config.manualAccessibilityBundles.contains(where: {
+           $0.caseInsensitiveCompare(bundle) == .orderedSame
+       })
+    {
+        // Electron lazily exposes its Chromium accessibility tree. Electron's
+        // documented third-party macOS integration enables it by setting this
+        // application-level AX attribute before traversing renderer content.
+        let error = AXUIElementSetAttributeValue(
+            appRef,
+            "AXManualAccessibility" as CFString,
+            kCFBooleanTrue
+        )
+        manualAccessibility = [
+            "requested": true,
+            "succeeded": error == .success,
+            "error_code": error.rawValue,
+        ]
+    }
+
+    // Query the actual focused UI element directly. This must not be inferred
+    // later by picking the first text-like node in the filtered tree: many apps
+    // expose several editors/search fields at once, and filtering may collapse
+    // their container hierarchy.
+    var focusedUIElementRef: CFTypeRef?
+    AXUIElementCopyAttributeValue(
+        appRef, kAXFocusedUIElementAttribute as CFString, &focusedUIElementRef
+    )
+    let focusedUIElement = focusedUIElementRef as! AXUIElement?
+
     // Identify the focused window so we can mark it in the output.
     var focusedWindowRef: CFTypeRef?
     AXUIElementCopyAttributeValue(
         appRef, kAXFocusedWindowAttribute as CFString, &focusedWindowRef
     )
-    let focusedElement = focusedWindowRef as! AXUIElement?
+    let focusedWindow = focusedWindowRef as! AXUIElement?
 
     // Get all children (AXChildren includes windows across all Spaces,
     // unlike kAXWindowsAttribute which only returns the current Space).
@@ -402,7 +434,7 @@ func processApp(pid: pid_t, name: String, bundleID: String?, isFrontmost: Bool, 
             let role = axString(child, kAXRoleAttribute as String)
             guard role == "AXWindow" else { continue }
 
-            let isFocusedWindow = focusedElement != nil && CFEqual(child, focusedElement!)
+            let isFocusedWindow = focusedWindow != nil && CFEqual(child, focusedWindow!)
 
             // If --focused-window-only, skip non-focused windows
             if config.focusedWindowOnly && !isFocusedWindow {
@@ -440,6 +472,18 @@ func processApp(pid: pid_t, name: String, bundleID: String?, isFrontmost: Bool, 
         "is_frontmost": isFrontmost,
     ]
     if let bid = bundleID { appDict["bundle_id"] = bid }
+    if let status = manualAccessibility {
+        appDict["manual_accessibility"] = status
+    }
+    if let focused = focusedUIElement,
+       let node = traverseElement(focused, depth: 1, config: config),
+       var dict = node.toDict()
+    {
+        // The value is already redacted by traverseElement for secure fields.
+        // Marking the direct result makes the Python fallback unambiguous.
+        dict["focused"] = true
+        appDict["focused_element"] = dict
+    }
     appDict["windows"] = windowDicts
     return appDict
 }
@@ -474,6 +518,11 @@ func parseArgs() -> Config {
             config.focusedWindowOnly = true
         case "--raw":
             config.raw = true
+        case "--manual-accessibility-bundle":
+            if let next = args.first {
+                config.manualAccessibilityBundles.append(next)
+                args = args.dropFirst()
+            }
         case "--help", "-h":
             fputs(
                 """
@@ -484,6 +533,8 @@ func parseArgs() -> Config {
                   --depth N           Max traversal depth (default: 8)
                   --timeout SECS      Per-app timeout in seconds (default: 3)
                   --raw               Preserve the unfiltered AX tree for debugging/parser work
+                  --manual-accessibility-bundle ID
+                                      Enable Electron AX renderer for this bundle (repeatable)
                 \n
                 """, stderr)
             exit(0)

--- a/resources/mac-ax-watcher.swift
+++ b/resources/mac-ax-watcher.swift
@@ -109,6 +109,18 @@ func describeElement(_ el: AXUIElement) -> [String: Any] {
     ]
 }
 
+/// Privacy-minimized element description for physical interaction signals.
+/// Unlike TextInput/MouseClick payloads, UserEnter never includes title/value.
+func describeSignalTarget(_ el: AXUIElement) -> [String: Any] {
+    return [
+        "role": axRole(el) ?? "",
+        "subrole": axSubrole(el) ?? "",
+        "identifier": truncate(
+            axString(el, kAXIdentifierAttribute as String) ?? "", 200
+        ),
+    ]
+}
+
 /// Resolve the owning app (name + bundle id) for an AX element.
 func appInfoForElement(_ el: AXUIElement) -> (pid: pid_t, name: String, bundleId: String) {
     var pid: pid_t = 0
@@ -174,6 +186,29 @@ let kTextInputDebounceSeconds: TimeInterval = 5.0
 /// uninterruptedly for this long we flush anyway so downstream consumers
 /// see activity rather than waiting indefinitely for a pause.
 let kTextInputMaxContinuousSeconds: TimeInterval = 60.0
+
+/// Classify the two physical Enter keys. Auto-repeat is intentionally
+/// rejected here so every caller shares the same behavior.
+func enterKeyVariant(keyCode: Int64, isRepeat: Bool) -> String? {
+    if isRepeat { return nil }
+    switch keyCode {
+    case 36:
+        return "return"
+    case 76:
+        return "keypad_enter"
+    default:
+        return nil
+    }
+}
+
+func enterModifierNames(_ flags: CGEventFlags) -> [String] {
+    var modifiers: [String] = []
+    if flags.contains(.maskShift) { modifiers.append("shift") }
+    if flags.contains(.maskCommand) { modifiers.append("command") }
+    if flags.contains(.maskControl) { modifiers.append("control") }
+    if flags.contains(.maskAlternate) { modifiers.append("option") }
+    return modifiers
+}
 
 final class InteractionTapper {
     private var eventTap: CFMachPort?
@@ -289,6 +324,63 @@ final class InteractionTapper {
 
     /// Called by the CGEventTap callback on a keyDown event.
     func handleKeyDown(_ event: CGEvent) {
+        let keyCode = event.getIntegerValueField(.keyboardEventKeycode)
+        let isRepeat =
+            event.getIntegerValueField(.keyboardEventAutorepeat) != 0
+        let keyVariant = enterKeyVariant(keyCode: keyCode, isRepeat: isRepeat)
+
+        // Enter is a physical interaction signal, including Command/Control
+        // variants, so it must be handled before shortcut filtering.
+        if let variant = keyVariant {
+            let signalID = UUID().uuidString.lowercased()
+            let flags = event.flags
+            let modifiers = enterModifierNames(flags)
+
+            var appInfo: (pid: pid_t, name: String, bundleId: String) = (0, "", "")
+            var target: [String: Any] = [:]
+            var targetStatus = "app_unavailable"
+            if let front = NSWorkspace.shared.frontmostApplication {
+                appInfo = (
+                    front.processIdentifier,
+                    front.localizedName ?? "",
+                    front.bundleIdentifier ?? ""
+                )
+                let appElement = AXUIElementCreateApplication(appInfo.pid)
+                if let element = focusedElement(appElement) {
+                    if isSecureElement(element) {
+                        targetStatus = "secure_input"
+                    } else {
+                        target = describeSignalTarget(element)
+                        targetStatus = "available"
+                    }
+                } else {
+                    targetStatus = "ax_unavailable"
+                }
+            }
+
+            // Preserve event order: any pending text belongs before the Enter.
+            // When no text is pending flushText is intentionally a no-op.
+            flushText(reason: "enter", associationID: signalID)
+
+            writer.write(event: [
+                "event_type": "UserEnter",
+                "signal_id": signalID,
+                "pid": appInfo.pid,
+                "app_name": appInfo.name,
+                "bundle_id": appInfo.bundleId,
+                // A window title may contain contacts, documents, URLs, or
+                // secrets. UserEnter does not need it for app correlation.
+                "window_title": "",
+                "timestamp": nowIsoLocal(),
+                "key_variant": variant,
+                "modifiers": modifiers,
+                "input_target": target,
+                "input_target_status": targetStatus,
+                "semantic_intent": "unknown",
+            ])
+            return
+        }
+
         // ⌘ / ⌃ held = shortcut (⌘S, ⌃C, etc.), not typing. Skip so the
         // debounce timer doesn't get reset by a keybind. ⌥ is allowed
         // through because it's commonly used for alternate characters
@@ -358,7 +450,7 @@ final class InteractionTapper {
 
     /// Emit a pending ``UserTextInput`` event if one is buffered. Safe to
     /// call from any thread; idempotent when there's nothing to flush.
-    func flushText(reason: String) {
+    func flushText(reason: String, associationID: String? = nil) {
         textLock.lock()
         guard typingStartedAt != nil else {
             textLock.unlock()
@@ -396,7 +488,7 @@ final class InteractionTapper {
             }
         }
 
-        writer.write(event: [
+        var textEvent: [String: Any] = [
             "event_type": "UserTextInput",
             "pid": app.pid,
             "app_name": app.name,
@@ -407,7 +499,11 @@ final class InteractionTapper {
                 "reason": reason,
                 "element": elementDict,
             ],
-        ])
+        ]
+        if let signalID = associationID {
+            textEvent["signal_id"] = signalID
+        }
+        writer.write(event: textEvent)
     }
 
     /// Re-enable the tap after the system disables it (e.g. because a
@@ -726,4 +822,31 @@ func main() {
     CFRunLoopRun()
 }
 
-main()
+func runEnterSelfTests() -> Bool {
+    let allFlags = CGEventFlags(
+        rawValue: CGEventFlags.maskShift.rawValue
+            | CGEventFlags.maskCommand.rawValue
+            | CGEventFlags.maskControl.rawValue
+            | CGEventFlags.maskAlternate.rawValue
+    )
+    let checks = [
+        enterKeyVariant(keyCode: 36, isRepeat: false) == "return",
+        enterKeyVariant(keyCode: 76, isRepeat: false) == "keypad_enter",
+        enterKeyVariant(keyCode: 0, isRepeat: false) == nil,
+        enterKeyVariant(keyCode: 36, isRepeat: true) == nil,
+        enterKeyVariant(keyCode: 76, isRepeat: true) == nil,
+        enterModifierNames(allFlags) == ["shift", "command", "control", "option"],
+    ]
+    if checks.allSatisfy({ $0 }) {
+        print("Enter self-tests passed")
+        return true
+    }
+    fputs("Enter self-tests failed\n", stderr)
+    return false
+}
+
+if CommandLine.arguments.contains("--self-test") {
+    exit(runEnterSelfTests() ? 0 : 1)
+} else {
+    main()
+}

--- a/resources/mac-ax-watcher.swift
+++ b/resources/mac-ax-watcher.swift
@@ -18,6 +18,47 @@ import AppKit
 import ApplicationServices
 import Foundation
 
+let kPrivacyPolicyVersion = 1
+
+struct PrivacyPolicy {
+    let version: Int
+    let excludedBundleIds: Set<String>
+    let loaded: Bool
+}
+
+func loadPrivacyPolicy(arguments: [String]) -> PrivacyPolicy {
+    if arguments.contains("--self-test") {
+        return PrivacyPolicy(
+            version: kPrivacyPolicyVersion,
+            excludedBundleIds: [],
+            loaded: true
+        )
+    }
+    var version: Int?
+    var excluded = Set<String>()
+    var index = 1
+    while index < arguments.count {
+        let argument = arguments[index]
+        if argument == "--privacy-policy-version", index + 1 < arguments.count {
+            version = Int(arguments[index + 1])
+            index += 2
+        } else if argument == "--exclude-bundle", index + 1 < arguments.count {
+            let bundleId = arguments[index + 1]
+            if !bundleId.isEmpty { excluded.insert(bundleId) }
+            index += 2
+        } else {
+            index += 1
+        }
+    }
+    return PrivacyPolicy(
+        version: version ?? -1,
+        excludedBundleIds: excluded,
+        loaded: version == kPrivacyPolicyVersion
+    )
+}
+
+let privacyPolicy = loadPrivacyPolicy(arguments: CommandLine.arguments)
+
 // MARK: - Event Output
 
 /// Thread-safe JSON line writer to stdout
@@ -150,6 +191,31 @@ func getWindowTitle(_ appElement: AXUIElement) -> String {
     // swiftlint:disable:next force_cast
     let winEl = window as! AXUIElement
     return axString(winEl, kAXTitleAttribute as String) ?? ""
+}
+
+/// Stable structural identity for the focused window when AX exposes its
+/// numeric window id. Falls back to bundle+pid without using a title.
+func focusedWindowIdentity(
+    _ appElement: AXUIElement,
+    bundleId: String,
+    pid: pid_t
+) -> (value: String, confidence: String) {
+    var windowRef: CFTypeRef?
+    let windowError = AXUIElementCopyAttributeValue(
+        appElement, kAXFocusedWindowAttribute as CFString, &windowRef
+    )
+    if windowError == .success, let rawWindow = windowRef {
+        // swiftlint:disable:next force_cast
+        let window = rawWindow as! AXUIElement
+        var numberRef: CFTypeRef?
+        let numberError = AXUIElementCopyAttributeValue(
+            window, "AXWindowNumber" as CFString, &numberRef
+        )
+        if numberError == .success, let number = numberRef as? NSNumber {
+            return ("\(bundleId):\(pid):\(number.int64Value)", "high")
+        }
+    }
+    return ("\(bundleId):\(pid)", "low")
 }
 
 // MARK: - Interaction Tapper
@@ -333,19 +399,35 @@ final class InteractionTapper {
         // variants, so it must be handled before shortcut filtering.
         if let variant = keyVariant {
             let signalID = UUID().uuidString.lowercased()
+            let correlationID = UUID().uuidString.lowercased()
             let flags = event.flags
             let modifiers = enterModifierNames(flags)
 
             var appInfo: (pid: pid_t, name: String, bundleId: String) = (0, "", "")
             var target: [String: Any] = [:]
             var targetStatus = "app_unavailable"
+            var windowIdentity = ""
+            var windowIdentityConfidence = "low"
             if let front = NSWorkspace.shared.frontmostApplication {
                 appInfo = (
                     front.processIdentifier,
                     front.localizedName ?? "",
                     front.bundleIdentifier ?? ""
                 )
+                if privacyPolicy.excludedBundleIds.contains(appInfo.bundleId) {
+                    // Block before flushText so excluded-app text never reaches
+                    // stdout. Python repeats the check as defense in depth.
+                    discardPendingText()
+                    return
+                }
                 let appElement = AXUIElementCreateApplication(appInfo.pid)
+                let identity = focusedWindowIdentity(
+                    appElement,
+                    bundleId: appInfo.bundleId,
+                    pid: appInfo.pid
+                )
+                windowIdentity = identity.value
+                windowIdentityConfidence = identity.confidence
                 if let element = focusedElement(appElement) {
                     if isSecureElement(element) {
                         targetStatus = "secure_input"
@@ -360,11 +442,17 @@ final class InteractionTapper {
 
             // Preserve event order: any pending text belongs before the Enter.
             // When no text is pending flushText is intentionally a no-op.
-            flushText(reason: "enter", associationID: signalID)
+            flushText(
+                reason: "enter",
+                correlationID: correlationID,
+                relatedSignalID: signalID
+            )
 
             writer.write(event: [
                 "event_type": "UserEnter",
                 "signal_id": signalID,
+                "correlation_id": correlationID,
+                "privacy_policy_version": privacyPolicy.version,
                 "pid": appInfo.pid,
                 "app_name": appInfo.name,
                 "bundle_id": appInfo.bundleId,
@@ -376,6 +464,8 @@ final class InteractionTapper {
                 "modifiers": modifiers,
                 "input_target": target,
                 "input_target_status": targetStatus,
+                "window_identity": windowIdentity,
+                "window_identity_confidence": windowIdentityConfidence,
                 "semantic_intent": "unknown",
             ])
             return
@@ -450,7 +540,22 @@ final class InteractionTapper {
 
     /// Emit a pending ``UserTextInput`` event if one is buffered. Safe to
     /// call from any thread; idempotent when there's nothing to flush.
-    func flushText(reason: String, associationID: String? = nil) {
+    func discardPendingText() {
+        textLock.lock()
+        typingStartedAt = nil
+        typingElement = nil
+        typingApp = (0, "", "")
+        typingWindowTitle = ""
+        textFlushTimer?.cancel()
+        textFlushTimer = nil
+        textLock.unlock()
+    }
+
+    func flushText(
+        reason: String,
+        correlationID: String? = nil,
+        relatedSignalID: String? = nil
+    ) {
         textLock.lock()
         guard typingStartedAt != nil else {
             textLock.unlock()
@@ -472,6 +577,10 @@ final class InteractionTapper {
         textFlushTimer = nil
         textLock.unlock()
 
+        if privacyPolicy.excludedBundleIds.contains(app.bundleId) {
+            return
+        }
+
         var elementDict: [String: Any] = [:]
         if let el = element {
             elementDict = describeElement(el)
@@ -490,6 +599,8 @@ final class InteractionTapper {
 
         var textEvent: [String: Any] = [
             "event_type": "UserTextInput",
+            "event_id": UUID().uuidString.lowercased(),
+            "privacy_policy_version": privacyPolicy.version,
             "pid": app.pid,
             "app_name": app.name,
             "bundle_id": app.bundleId,
@@ -500,8 +611,11 @@ final class InteractionTapper {
                 "element": elementDict,
             ],
         ]
-        if let signalID = associationID {
-            textEvent["signal_id"] = signalID
+        if let correlationID = correlationID {
+            textEvent["correlation_id"] = correlationID
+        }
+        if let relatedSignalID = relatedSignalID {
+            textEvent["related_signal_id"] = relatedSignalID
         }
         writer.write(event: textEvent)
     }
@@ -847,6 +961,9 @@ func runEnterSelfTests() -> Bool {
 
 if CommandLine.arguments.contains("--self-test") {
     exit(runEnterSelfTests() ? 0 : 1)
+} else if !privacyPolicy.loaded {
+    fputs("Privacy policy missing or unsupported; watcher refusing to start\n", stderr)
+    exit(3)
 } else {
     main()
 }

--- a/src/openchronicle/capture/ax_capture.py
+++ b/src/openchronicle/capture/ax_capture.py
@@ -155,11 +155,20 @@ class UnavailableAXProvider:
 class MacAXHelperProvider:
     """Subprocess wrapper around the vendored mac-ax-helper Swift binary."""
 
-    def __init__(self, *, helper_path: Path, depth: int, timeout: int, raw: bool = False) -> None:
+    def __init__(
+        self,
+        *,
+        helper_path: Path,
+        depth: int,
+        timeout: int,
+        raw: bool = False,
+        manual_accessibility_bundles: list[str] | None = None,
+    ) -> None:
         self._helper_path = str(helper_path)
         self._depth = depth
         self._timeout = timeout
         self._raw = raw
+        self._manual_accessibility_bundles = manual_accessibility_bundles or []
 
     @property
     def available(self) -> bool:
@@ -194,14 +203,14 @@ class MacAXHelperProvider:
             args.append("--focused-window-only")
         if self._raw:
             args.append("--raw")
+        for bundle in self._manual_accessibility_bundles:
+            args.extend(["--manual-accessibility-bundle", bundle])
         if self._depth > 0:
             args.extend(["--depth", str(self._depth)])
         args.extend(["--timeout", str(self._timeout)])
 
         try:
-            proc = subprocess.run(
-                args, capture_output=True, text=True, timeout=_SUBPROCESS_TIMEOUT
-            )
+            proc = subprocess.run(args, capture_output=True, text=True, timeout=_SUBPROCESS_TIMEOUT)
         except subprocess.TimeoutExpired:
             logger.warning("mac-ax-helper timed out after %ds", _SUBPROCESS_TIMEOUT)
             return None
@@ -229,15 +238,35 @@ class MacAXHelperProvider:
 
         data = _strip_frame_fields(data)
         mode = "all-visible" if all_visible else "frontmost"
+        manual_accessibility = [
+            {
+                "bundle_id": app.get("bundle_id", ""),
+                **app["manual_accessibility"],
+            }
+            for app in data.get("apps", [])
+            if isinstance(app.get("manual_accessibility"), dict)
+        ]
         return AXCaptureResult(
             raw_json=data,
             timestamp=data.get("timestamp", ""),
             apps=data.get("apps", []),
-            metadata={"mode": mode, "depth": self._depth, "platform": "macos", "raw": self._raw},
+            metadata={
+                "mode": mode,
+                "depth": self._depth,
+                "platform": "macos",
+                "raw": self._raw,
+                "manual_accessibility": manual_accessibility,
+            },
         )
 
 
-def create_provider(*, depth: int = 8, timeout: int = 3, raw: bool = False) -> AXProvider:
+def create_provider(
+    *,
+    depth: int = 8,
+    timeout: int = 3,
+    raw: bool = False,
+    manual_accessibility_bundles: list[str] | None = None,
+) -> AXProvider:
     if platform.system() != "Darwin":
         return UnavailableAXProvider(f"unsupported platform: {platform.system()}")
     helper = _resolve_helper_path()
@@ -246,4 +275,10 @@ def create_provider(*, depth: int = 8, timeout: int = 3, raw: bool = False) -> A
             "mac-ax-helper not found. Build it: bash resources/build-mac-ax-helper.sh"
         )
     logger.info("AX capture initialized: %s", helper)
-    return MacAXHelperProvider(helper_path=helper, depth=depth, timeout=timeout, raw=raw)
+    return MacAXHelperProvider(
+        helper_path=helper,
+        depth=depth,
+        timeout=timeout,
+        raw=raw,
+        manual_accessibility_bundles=manual_accessibility_bundles,
+    )

--- a/src/openchronicle/capture/event_dispatcher.py
+++ b/src/openchronicle/capture/event_dispatcher.py
@@ -39,6 +39,7 @@ _IMMEDIATE_EVENTS = {
 }
 _DEBOUNCED_EVENTS = {"AXValueChanged"}
 _SKIP_EVENTS = {"AXTitleChanged"}
+_SAFE_ELEMENT_FIELDS = ("role", "subrole", "identifier")
 
 
 class EventDispatcher:
@@ -102,6 +103,22 @@ class EventDispatcher:
             "bundle_id": bundle_id,
             "window_title": window_title,
         }
+        details = raw.get("details")
+        if isinstance(details, dict):
+            safe_details: dict[str, Any] = {}
+            if isinstance(details.get("reason"), str):
+                safe_details["reason"] = details["reason"][:80]
+            if isinstance(details.get("button"), int):
+                safe_details["button"] = details["button"]
+            element = details.get("element")
+            if isinstance(element, dict):
+                safe_element = {
+                    key: str(element[key])[:200] for key in _SAFE_ELEMENT_FIELDS if element.get(key)
+                }
+                if safe_element:
+                    safe_details["element"] = safe_element
+            if safe_details:
+                trigger["details"] = safe_details
 
         if event_type in _IMMEDIATE_EVENTS:
             self._cancel_debounce()
@@ -111,9 +128,7 @@ class EventDispatcher:
 
     def _prune_event_times(self, now: float) -> None:
         cutoff = now - self._dedup_interval
-        self._last_event_time = {
-            k: t for k, t in self._last_event_time.items() if t >= cutoff
-        }
+        self._last_event_time = {k: t for k, t in self._last_event_time.items() if t >= cutoff}
 
     def _schedule_debounce(self, trigger: dict[str, Any]) -> None:
         with self._lock:
@@ -164,15 +179,14 @@ class EventDispatcher:
             ):
                 logger.debug(
                     "capture skipped (same-window dedup <%.1fs): %s",
-                    self._same_window_dedup, trigger["window_title"][:40],
+                    self._same_window_dedup,
+                    trigger["window_title"][:40],
                 )
                 return
 
             gap = now - self._last_capture_monotonic
             if gap < self._min_capture_gap and not is_focus_change:
-                logger.debug(
-                    "capture skipped (rate limit %.1fs): %s", gap, event_type
-                )
+                logger.debug("capture skipped (rate limit %.1fs): %s", gap, event_type)
                 return
 
             self._last_capture_key = key

--- a/src/openchronicle/capture/event_dispatcher.py
+++ b/src/openchronicle/capture/event_dispatcher.py
@@ -24,7 +24,10 @@ from __future__ import annotations
 
 import threading
 import time
+import uuid
 from collections.abc import Callable
+from dataclasses import dataclass, field
+from datetime import UTC, datetime, timedelta
 from typing import Any
 
 from ..logger import get
@@ -41,6 +44,49 @@ _IMMEDIATE_EVENTS = {
 _DEBOUNCED_EVENTS = {"AXValueChanged"}
 _SKIP_EVENTS = {"AXTitleChanged"}
 _SAFE_ELEMENT_FIELDS = ("role", "subrole", "identifier")
+_NO_FOLLOWUP_STATUSES = {
+    "new",
+    "privacy_blocked",
+    "app_changed",
+    "permission_denied",
+    "screen_locked",
+}
+_RETRYABLE_STATUSES = {
+    "reused",
+    "unchanged",
+    "deferred_queue_full",
+    "ax_incomplete",
+    "capture_unavailable",
+}
+_RETRYABLE_DEGRADED_REASONS = {
+    "ax_incomplete",
+    "capture_unavailable",
+    "duplicate_without_ref",
+    "queue_full",
+    "temporary_capture_error",
+}
+
+
+def _now_iso() -> str:
+    return datetime.now(UTC).astimezone().isoformat(timespec="milliseconds")
+
+
+@dataclass
+class _CaptureGroup:
+    capture_request_id: str
+    key: tuple[str, int, str]
+    bundle_id: str
+    pid: int
+    window_identity: str
+    window_identity_confidence: str
+    created_at: str
+    due_at: str
+    member_signal_ids: list[str] = field(default_factory=list)
+    timer: threading.Timer | None = None
+    running: bool = False
+    phase: str = "primary"
+    attempt_id: str | None = None
+    natural_attempted: bool = False
 
 
 class EventDispatcher:
@@ -56,6 +102,7 @@ class EventDispatcher:
         capture_fn: Callable[[dict[str, Any]], None],
         *,
         signal_store: SignalStore | None = None,
+        context_snapshot_ref_fn: Callable[[str], str | None] | None = None,
         enter_capture_delay_seconds: float = 0.2,
         # Sample after the documented 800ms update boundary rather than
         # exactly on it, avoiding a race with UI work scheduled for T+800ms.
@@ -67,6 +114,7 @@ class EventDispatcher:
     ) -> None:
         self._capture_fn = capture_fn
         self._signal_store = signal_store
+        self._context_snapshot_ref_fn = context_snapshot_ref_fn
         self._enter_capture_delay = enter_capture_delay_seconds
         self._enter_followup_delay = enter_followup_delay_seconds
         self._debounce_seconds = debounce_seconds
@@ -77,6 +125,9 @@ class EventDispatcher:
         self._lock = threading.Lock()
         self._debounce_timer: threading.Timer | None = None
         self._enter_timers: set[threading.Timer] = set()
+        self._active_groups: dict[tuple[str, int, str], _CaptureGroup] = {}
+        self._waiting_groups: dict[tuple[str, int, str], _CaptureGroup] = {}
+        self._draining = False
         self._pending_trigger: dict[str, Any] | None = None
 
         # Tuple keys avoid the silent collision a delimited-string key has
@@ -95,8 +146,21 @@ class EventDispatcher:
         event_type = raw.get("event_type", "")
         if not event_type or event_type in _SKIP_EVENTS:
             return
+        bundle_id = str(raw.get("bundle_id") or "")
+        if self._signal_store and self._signal_store.is_excluded_bundle(bundle_id):
+            return
+        if self._draining:
+            return
         if event_type == "UserEnter":
             self._handle_user_enter(raw)
+            return
+        if (
+            event_type == "UserTextInput"
+            and self._signal_store is not None
+            and not self._signal_store.create_user_text_input(raw).created
+        ):
+            return
+        if event_type == "AXValueChanged" and self._try_natural_enter_capture(raw):
             return
 
         bundle_id = raw.get("bundle_id", "") or ""
@@ -116,9 +180,15 @@ class EventDispatcher:
             "bundle_id": bundle_id,
             "window_title": window_title,
         }
-        association_id = raw.get("signal_id")
-        if isinstance(association_id, str) and 0 < len(association_id) <= 128:
-            trigger["signal_id"] = association_id
+        event_id = raw.get("event_id")
+        if isinstance(event_id, str) and 0 < len(event_id) <= 128:
+            trigger["event_id"] = event_id
+        correlation_id = raw.get("correlation_id")
+        if isinstance(correlation_id, str) and 0 < len(correlation_id) <= 128:
+            trigger["correlation_id"] = correlation_id
+        related_signal_id = raw.get("related_signal_id")
+        if isinstance(related_signal_id, str) and 0 < len(related_signal_id) <= 128:
+            trigger["related_signal_id"] = related_signal_id
         details = raw.get("details")
         if isinstance(details, dict):
             safe_details: dict[str, Any] = {}
@@ -143,53 +213,317 @@ class EventDispatcher:
             self._schedule_debounce(trigger)
 
     def _handle_user_enter(self, raw: dict[str, Any]) -> None:
-        """Persist Enter before requesting capture and bypass event dedup."""
+        """Persist Enter, then coalesce its conditional Capture request."""
         if self._signal_store is None:
             logger.warning("UserEnter ignored: signal store unavailable")
             return
+        raw = dict(raw)
+        if self._context_snapshot_ref_fn is not None:
+            raw.setdefault(
+                "context_snapshot_ref",
+                self._context_snapshot_ref_fn(str(raw.get("bundle_id") or "")),
+            )
+        raw.setdefault(
+            "correlation_deadline",
+            (
+                datetime.now(UTC).astimezone()
+                + timedelta(seconds=max(10.0, (self._enter_followup_delay or 0) + 1.0))
+            ).isoformat(timespec="milliseconds"),
+        )
         result = self._signal_store.create_user_enter(raw)
         if not result.created:
             return
 
+        bundle_id = str(raw.get("bundle_id") or "")[:300]
+        pid = raw.get("pid") if isinstance(raw.get("pid"), int) else 0
+        window_identity = str(raw.get("window_identity") or f"{bundle_id}:{pid}")[:200]
+        confidence = str(raw.get("window_identity_confidence") or "low")
+        key = (bundle_id, pid, window_identity)
+        with self._lock:
+            active = self._active_groups.get(key)
+            if active is None:
+                group = self._new_group(
+                    key, bundle_id, pid, window_identity, confidence, self._enter_capture_delay
+                )
+                group.member_signal_ids.append(result.signal_id)
+                self._active_groups[key] = group
+                self._schedule_group_locked(group, self._enter_capture_delay)
+            elif not active.running and active.phase == "primary":
+                active.member_signal_ids.append(result.signal_id)
+                group = active
+            else:
+                group = self._waiting_groups.get(key)
+                if group is None:
+                    group = self._new_group(
+                        key,
+                        bundle_id,
+                        pid,
+                        window_identity,
+                        confidence,
+                        self._enter_capture_delay,
+                    )
+                    self._waiting_groups[key] = group
+                group.member_signal_ids.append(result.signal_id)
+
+        self._signal_store.update_linkage(
+            result.signal_id,
+            capture_request_id=group.capture_request_id,
+        )
+
+    def recover_signal(self, signal: dict[str, Any]) -> bool:
+        """Schedule one conservative startup recovery for a V2 Signal."""
+        if self._signal_store is None:
+            return False
+        signal_id = str(signal.get("signal_id") or "")
+        deadline_text = str(signal.get("correlation_deadline") or "")
+        try:
+            deadline = datetime.fromisoformat(deadline_text)
+        except ValueError:
+            deadline = datetime.min.replace(tzinfo=UTC)
+        confidence = str(signal.get("window_identity_confidence") or "low")
+        if deadline <= datetime.now(UTC).astimezone() or confidence != "high":
+            reason = "recovery_expired" if deadline_text and deadline <= datetime.now(
+                UTC
+            ).astimezone() else "context_changed"
+            self._signal_store.update_linkage(
+                signal_id,
+                attempt={
+                    "attempt_id": f"att-{uuid.uuid4().hex}",
+                    "phase": "recovery",
+                    "association_mode": "recovery",
+                    "status": "unresolved",
+                    "completed_at": _now_iso(),
+                    "bundle_id": signal.get("bundle_id"),
+                    "window_identity": signal.get("window_identity"),
+                    "window_identity_confidence": confidence,
+                    "quality_status": "failed",
+                    "error_reason": reason,
+                },
+                post_capture_status="unresolved",
+                quality_status="failed",
+            )
+            return False
+
+        bundle_id = str(signal.get("bundle_id") or "")
+        pid = signal.get("pid") if isinstance(signal.get("pid"), int) else 0
+        window_identity = str(signal.get("window_identity") or "")
+        key = (bundle_id, pid, window_identity)
+        group = self._new_group(
+            key,
+            bundle_id,
+            pid,
+            window_identity,
+            confidence,
+            0,
+        )
+        group.phase = "recovery"
+        group.member_signal_ids.append(signal_id)
+        with self._lock:
+            if key in self._active_groups:
+                return False
+            self._active_groups[key] = group
+            self._schedule_group_locked(group, 0)
+        return True
+
+    def _new_group(
+        self,
+        key: tuple[str, int, str],
+        bundle_id: str,
+        pid: int,
+        window_identity: str,
+        confidence: str,
+        delay: float,
+    ) -> _CaptureGroup:
+        now = datetime.now(UTC).astimezone()
+        return _CaptureGroup(
+            capture_request_id=f"cap-{uuid.uuid4().hex}",
+            key=key,
+            bundle_id=bundle_id,
+            pid=pid,
+            window_identity=window_identity,
+            window_identity_confidence=confidence,
+            created_at=now.isoformat(timespec="milliseconds"),
+            due_at=(now + timedelta(seconds=delay)).isoformat(timespec="milliseconds"),
+        )
+
+    def _try_natural_enter_capture(self, raw: dict[str, Any]) -> bool:
+        bundle_id = str(raw.get("bundle_id") or "")
+        pid = raw.get("pid") if isinstance(raw.get("pid"), int) else 0
+        with self._lock:
+            candidates = [
+                group
+                for group in self._active_groups.values()
+                if group.bundle_id == bundle_id
+                and group.pid == pid
+                and group.phase == "follow_up"
+                and not group.running
+                and not group.natural_attempted
+            ]
+            if len(candidates) != 1:
+                return False
+            group = candidates[0]
+            if group.timer is not None:
+                group.timer.cancel()
+                self._enter_timers.discard(group.timer)
+            group.natural_attempted = True
+            group.phase = "natural_event"
+            self._schedule_group_locked(group, 0)
+            return True
+
+    def _schedule_group_locked(self, group: _CaptureGroup, delay: float) -> None:
+        timer = threading.Timer(delay, self._run_group, args=(group,))
+        timer.daemon = True
+        group.timer = timer
+        self._enter_timers.add(timer)
+        timer.start()
+
+    def _run_group(self, group: _CaptureGroup) -> None:
+        with self._lock:
+            if self._draining:
+                self._enter_timers.discard(group.timer)
+                return
+            group.running = True
+            member_ids = tuple(group.member_signal_ids)
+            group.attempt_id = f"att-{uuid.uuid4().hex}"
+            self._enter_timers.discard(group.timer)
+
+        requested_at = _now_iso()
+        attempt = {
+            "attempt_id": group.attempt_id,
+            "capture_request_id": group.capture_request_id,
+            "phase": group.phase,
+            "association_mode": "coalesced" if len(member_ids) > 1 else "direct",
+            "requested_at": requested_at,
+            "due_at": group.due_at,
+            "started_at": requested_at,
+            "bundle_id": group.bundle_id,
+            "window_identity": group.window_identity,
+            "window_identity_confidence": group.window_identity_confidence,
+            "status": "running",
+        }
+        for signal_id in member_ids:
+            self._signal_store.update_linkage(
+                signal_id,
+                attempt=attempt,
+                capture_request_id=group.capture_request_id,
+                post_capture_status="running" if group.phase == "primary" else None,
+            )
+
         trigger = {
             "event_type": "UserEnter",
-            "signal_id": result.signal_id,
-            "pid": raw.get("pid", 0),
-            "app_name": str(raw.get("app_name") or "")[:200],
-            "bundle_id": str(raw.get("bundle_id") or "")[:300],
-            # Never pass a watcher window title into logs/capture metadata.
+            "signal_id": member_ids[0],
+            "member_signal_ids": list(member_ids),
+            "capture_request_id": group.capture_request_id,
+            "attempt_id": group.attempt_id,
+            "enter_attempt": "initial" if group.phase == "primary" else group.phase,
+            "phase": group.phase,
+            "pid": group.pid,
+            "bundle_id": group.bundle_id,
+            "window_identity": group.window_identity,
+            "window_identity_confidence": group.window_identity_confidence,
             "window_title": "",
+            "_capture_complete": lambda outcome: self._complete_group(group, member_ids, outcome),
         }
+        try:
+            self._capture_fn(trigger)
+        except Exception as exc:  # noqa: BLE001
+            self._complete_group(
+                group,
+                member_ids,
+                {
+                    "status": "unresolved",
+                    "quality_status": "failed",
+                    "error_reason": type(exc).__name__,
+                },
+            )
 
-        def schedule_request(delay: float, attempt: str) -> None:
-            timer: threading.Timer
+    def _complete_group(
+        self,
+        group: _CaptureGroup,
+        member_ids: tuple[str, ...],
+        outcome: dict[str, Any],
+    ) -> None:
+        attempt_status = str(outcome.get("status") or "unresolved")
+        status = attempt_status
+        if attempt_status in {"capture_unavailable", "ax_incomplete"}:
+            status = "pending" if group.phase == "primary" else "unresolved"
+        if status == "deferred_queue_full" and group.phase in {
+            "follow_up",
+            "recovery",
+        }:
+            status = "unresolved"
+            outcome = {**outcome, "error_reason": "queue_full_exhausted"}
+        quality = str(outcome.get("quality_status") or "failed")
+        snapshot_ref = outcome.get("snapshot_ref")
+        context_snapshot_ref = outcome.get("context_snapshot_ref")
+        completed_at = _now_iso()
+        attempt = {
+            "attempt_id": group.attempt_id,
+            "capture_request_id": group.capture_request_id,
+            "phase": group.phase,
+            "association_mode": (
+                "coalesced"
+                if len(member_ids) > 1
+                else ("reused" if status in {"reused", "unchanged"} else "direct")
+            ),
+            "completed_at": completed_at,
+            "bundle_id": group.bundle_id,
+            "window_identity": group.window_identity,
+            "window_identity_confidence": group.window_identity_confidence,
+            "status": attempt_status,
+            "snapshot_ref": snapshot_ref,
+            "quality_status": quality,
+            "error_reason": outcome.get("error_reason"),
+        }
+        for signal_id in member_ids:
+            self._signal_store.update_linkage(
+                signal_id,
+                attempt=attempt,
+                post_capture_status=status,
+                quality_status=quality,
+                result_snapshot_ref=snapshot_ref,
+                context_snapshot_ref=context_snapshot_ref,
+                capture_request_id=group.capture_request_id,
+            )
 
-            def request_capture() -> None:
-                attempt_trigger = {**trigger, "enter_attempt": attempt}
-                try:
-                    self._capture_fn(attempt_trigger)
-                except Exception as exc:  # noqa: BLE001
-                    self._signal_store.update_snapshot(
-                        result.signal_id, status="capture_request_failed"
-                    )
-                    logger.warning(
-                        "Enter capture request failed: id=%s error=%s",
-                        result.signal_id,
-                        type(exc).__name__,
-                    )
-                finally:
-                    with self._lock:
-                        self._enter_timers.discard(timer)
-
-            timer = threading.Timer(delay, request_capture)
-            timer.daemon = True
-            with self._lock:
-                self._enter_timers.add(timer)
-            timer.start()
-
-        schedule_request(self._enter_capture_delay, "initial")
-        if self._enter_followup_delay is not None:
-            schedule_request(self._enter_followup_delay, "followup")
+        should_follow_up = (
+            group.phase == "primary"
+            and self._enter_followup_delay is not None
+            and (
+                attempt_status in _RETRYABLE_STATUSES
+                or (
+                    quality == "degraded"
+                    and outcome.get("error_reason") in _RETRYABLE_DEGRADED_REASONS
+                )
+            )
+            and status not in _NO_FOLLOWUP_STATUSES
+        )
+        natural_event_failed = (
+            group.phase == "natural_event"
+            and (
+                attempt_status in _RETRYABLE_STATUSES
+                or (
+                    quality == "degraded"
+                    and outcome.get("error_reason") in _RETRYABLE_DEGRADED_REASONS
+                )
+            )
+            and status not in _NO_FOLLOWUP_STATUSES
+        )
+        with self._lock:
+            group.running = False
+            if (should_follow_up or natural_event_failed) and not self._draining:
+                group.phase = "follow_up"
+                group.due_at = (
+                    datetime.now(UTC).astimezone()
+                    + timedelta(seconds=self._enter_followup_delay or 0)
+                ).isoformat(timespec="milliseconds")
+                self._schedule_group_locked(group, self._enter_followup_delay or 0)
+                return
+            self._active_groups.pop(group.key, None)
+            waiting = self._waiting_groups.pop(group.key, None)
+            if waiting is not None and not self._draining:
+                self._active_groups[group.key] = waiting
+                self._schedule_group_locked(waiting, self._enter_capture_delay)
 
     def _prune_event_times(self, now: float) -> None:
         cutoff = now - self._dedup_interval
@@ -263,9 +597,12 @@ class EventDispatcher:
             logger.warning("capture callback failed: %s", exc)
 
     def shutdown(self) -> None:
+        self._draining = True
         self._cancel_debounce()
         with self._lock:
             timers = list(self._enter_timers)
             self._enter_timers.clear()
         for timer in timers:
             timer.cancel()
+        if self._signal_store is not None:
+            self._signal_store.defer_pending_for_shutdown()

--- a/src/openchronicle/capture/event_dispatcher.py
+++ b/src/openchronicle/capture/event_dispatcher.py
@@ -28,6 +28,7 @@ from collections.abc import Callable
 from typing import Any
 
 from ..logger import get
+from .signal_store import SignalStore
 
 logger = get("openchronicle.capture")
 
@@ -54,12 +55,20 @@ class EventDispatcher:
         self,
         capture_fn: Callable[[dict[str, Any]], None],
         *,
+        signal_store: SignalStore | None = None,
+        enter_capture_delay_seconds: float = 0.2,
+        # Sample after the documented 800ms update boundary rather than
+        # exactly on it, avoiding a race with UI work scheduled for T+800ms.
+        enter_followup_delay_seconds: float | None = 1.0,
         debounce_seconds: float = 3.0,
         min_capture_gap_seconds: float = 2.0,
         dedup_interval_seconds: float = 1.0,
         same_window_dedup_seconds: float = 5.0,
     ) -> None:
         self._capture_fn = capture_fn
+        self._signal_store = signal_store
+        self._enter_capture_delay = enter_capture_delay_seconds
+        self._enter_followup_delay = enter_followup_delay_seconds
         self._debounce_seconds = debounce_seconds
         self._min_capture_gap = min_capture_gap_seconds
         self._dedup_interval = dedup_interval_seconds
@@ -67,6 +76,7 @@ class EventDispatcher:
 
         self._lock = threading.Lock()
         self._debounce_timer: threading.Timer | None = None
+        self._enter_timers: set[threading.Timer] = set()
         self._pending_trigger: dict[str, Any] | None = None
 
         # Tuple keys avoid the silent collision a delimited-string key has
@@ -84,6 +94,9 @@ class EventDispatcher:
         """Watcher callback. Classifies the event and (maybe) triggers capture."""
         event_type = raw.get("event_type", "")
         if not event_type or event_type in _SKIP_EVENTS:
+            return
+        if event_type == "UserEnter":
+            self._handle_user_enter(raw)
             return
 
         bundle_id = raw.get("bundle_id", "") or ""
@@ -103,6 +116,9 @@ class EventDispatcher:
             "bundle_id": bundle_id,
             "window_title": window_title,
         }
+        association_id = raw.get("signal_id")
+        if isinstance(association_id, str) and 0 < len(association_id) <= 128:
+            trigger["signal_id"] = association_id
         details = raw.get("details")
         if isinstance(details, dict):
             safe_details: dict[str, Any] = {}
@@ -125,6 +141,55 @@ class EventDispatcher:
             self._maybe_capture(trigger)
         elif event_type in _DEBOUNCED_EVENTS:
             self._schedule_debounce(trigger)
+
+    def _handle_user_enter(self, raw: dict[str, Any]) -> None:
+        """Persist Enter before requesting capture and bypass event dedup."""
+        if self._signal_store is None:
+            logger.warning("UserEnter ignored: signal store unavailable")
+            return
+        result = self._signal_store.create_user_enter(raw)
+        if not result.created:
+            return
+
+        trigger = {
+            "event_type": "UserEnter",
+            "signal_id": result.signal_id,
+            "pid": raw.get("pid", 0),
+            "app_name": str(raw.get("app_name") or "")[:200],
+            "bundle_id": str(raw.get("bundle_id") or "")[:300],
+            # Never pass a watcher window title into logs/capture metadata.
+            "window_title": "",
+        }
+
+        def schedule_request(delay: float, attempt: str) -> None:
+            timer: threading.Timer
+
+            def request_capture() -> None:
+                attempt_trigger = {**trigger, "enter_attempt": attempt}
+                try:
+                    self._capture_fn(attempt_trigger)
+                except Exception as exc:  # noqa: BLE001
+                    self._signal_store.update_snapshot(
+                        result.signal_id, status="capture_request_failed"
+                    )
+                    logger.warning(
+                        "Enter capture request failed: id=%s error=%s",
+                        result.signal_id,
+                        type(exc).__name__,
+                    )
+                finally:
+                    with self._lock:
+                        self._enter_timers.discard(timer)
+
+            timer = threading.Timer(delay, request_capture)
+            timer.daemon = True
+            with self._lock:
+                self._enter_timers.add(timer)
+            timer.start()
+
+        schedule_request(self._enter_capture_delay, "initial")
+        if self._enter_followup_delay is not None:
+            schedule_request(self._enter_followup_delay, "followup")
 
     def _prune_event_times(self, now: float) -> None:
         cutoff = now - self._dedup_interval
@@ -199,3 +264,8 @@ class EventDispatcher:
 
     def shutdown(self) -> None:
         self._cancel_debounce()
+        with self._lock:
+            timers = list(self._enter_timers)
+            self._enter_timers.clear()
+        for timer in timers:
+            timer.cancel()

--- a/src/openchronicle/capture/s1_parser.py
+++ b/src/openchronicle/capture/s1_parser.py
@@ -16,6 +16,7 @@ from __future__ import annotations
 import re
 from dataclasses import asdict, dataclass
 from typing import Any
+from urllib.parse import urlsplit, urlunsplit
 
 from .ax_models import ax_app_to_markdown
 
@@ -29,7 +30,7 @@ _BROWSER_BUNDLES = {
     "com.operasoftware.Opera",
 }
 
-_URL_RE = re.compile(r"https?://\S+")
+_URL_RE = re.compile(r"^[^\s]+$")
 
 _EDITABLE_ROLES = {"AXTextField", "AXTextArea", "AXComboBox"}
 _STATIC_ROLES = {"AXStaticText", "AXWebArea"}
@@ -70,11 +71,14 @@ def enrich(capture: dict[str, Any]) -> None:
         capture["focused_element"] = FocusedElement().to_dict()
         capture["visible_text"] = ""
         capture["url"] = None
+        capture["url_source"] = "unavailable"
         return
 
     capture["focused_element"] = _extract_focused_element(app_data).to_dict()
     capture["visible_text"] = _render_visible_text(app_data)
-    capture["url"] = _extract_url(app_data)
+    url, source = _extract_url(app_data)
+    capture["url"] = url
+    capture["url_source"] = source
 
 
 def _frontmost_app(ax_tree: dict[str, Any]) -> dict[str, Any] | None:
@@ -86,26 +90,44 @@ def _frontmost_app(ax_tree: dict[str, Any]) -> dict[str, Any] | None:
 
 
 def _extract_focused_element(app_data: dict[str, Any]) -> FocusedElement:
+    direct = app_data.get("focused_element")
+    if isinstance(direct, dict):
+        return _focused_element_from_node(direct)
+
     for window in app_data.get("windows", []):
         if not window.get("focused"):
             continue
-        for el in window.get("elements", []):
-            role = el.get("role", "") or ""
-            if role in _EDITABLE_ROLES:
-                return FocusedElement(
-                    role=role,
-                    title=(el.get("title") or "")[:_FOCUS_TITLE_MAX],
-                    value=(el.get("value") or "")[:_FOCUS_VALUE_MAX],
-                    is_editable=True,
-                )
-            if role in _STATIC_ROLES:
-                return FocusedElement(
-                    role=role,
-                    title=(el.get("title") or "")[:_FOCUS_TITLE_MAX],
-                    value=(el.get("value") or el.get("title") or "")[:_FOCUS_VALUE_MAX],
-                    is_editable=False,
-                )
+        # Compatibility fallback for fixtures/older helpers: recurse, but only
+        # trust a node explicitly marked focused. An arbitrary first text node
+        # is worse than an empty result.
+        for el, _ancestors in _walk_elements(window.get("elements", [])):
+            if el.get("focused") is True:
+                return _focused_element_from_node(el)
     return FocusedElement()
+
+
+def _focused_element_from_node(node: dict[str, Any]) -> FocusedElement:
+    role = node.get("role", "") or ""
+    value = node.get("value") or ""
+    if role in _STATIC_ROLES and not value:
+        value = node.get("title") or ""
+    return FocusedElement(
+        role=role,
+        title=(node.get("title") or "")[:_FOCUS_TITLE_MAX],
+        value=value[:_FOCUS_VALUE_MAX],
+        is_editable=role in _EDITABLE_ROLES,
+    )
+
+
+def _walk_elements(elements: list[dict[str, Any]], ancestors: tuple[str, ...] = ()):
+    for el in elements:
+        if not isinstance(el, dict):
+            continue
+        role = el.get("role", "") or ""
+        yield el, ancestors
+        children = el.get("children") or []
+        if isinstance(children, list):
+            yield from _walk_elements(children, (*ancestors, role))
 
 
 def _render_visible_text(app_data: dict[str, Any]) -> str:
@@ -115,19 +137,83 @@ def _render_visible_text(app_data: dict[str, Any]) -> str:
     return md
 
 
-def _extract_url(app_data: dict[str, Any]) -> str | None:
+def _extract_url(app_data: dict[str, Any]) -> tuple[str | None, str]:
     bundle = app_data.get("bundle_id", "")
     if bundle not in _BROWSER_BUNDLES:
-        return None
+        return None, "unavailable"
+
+    strong: list[str] = []
+    toolbar: list[str] = []
     for window in app_data.get("windows", []):
-        for el in window.get("elements", []):
-            if el.get("role") != "AXTextField":
+        if not window.get("focused"):
+            continue
+        for el, ancestors in _walk_elements(window.get("elements", [])):
+            if el.get("role") not in {"AXTextField", "AXComboBox"}:
                 continue
-            value = (el.get("value") or "").strip()
-            if not value:
+            value = _normalize_url(el.get("value") or "")
+            if value is None:
                 continue
-            if _URL_RE.search(value):
-                return value
-            if "." in value and " " not in value:
-                return f"https://{value}"
-    return None
+            semantic = " ".join(
+                str(el.get(key) or "")
+                for key in ("title", "description", "identifier", "domIdentifier")
+            ).lower()
+            is_address_semantic = any(
+                marker in semantic
+                for marker in ("address", "location", "omnibox", "url bar", "search bar")
+            )
+            in_toolbar = "AXToolbar" in ancestors
+            in_web_area = "AXWebArea" in ancestors
+            if is_address_semantic and not in_web_area:
+                strong.append(value)
+            elif in_toolbar:
+                toolbar.append(value)
+
+    candidates = list(dict.fromkeys(strong))
+    if len(candidates) == 1:
+        return candidates[0], "ax_address_bar"
+    if len(candidates) > 1:
+        return None, "unavailable"
+
+    candidates = list(dict.fromkeys(toolbar))
+    if len(candidates) == 1:
+        return candidates[0], "ax_address_bar"
+    return None, "unavailable"
+
+
+def _normalize_url(raw: str) -> str | None:
+    value = raw.strip()
+    if not value or not _URL_RE.fullmatch(value):
+        return None
+
+    candidate = value
+    if "://" not in candidate:
+        if (
+            "." not in candidate
+            and candidate != "localhost"
+            and not candidate.startswith("localhost:")
+        ):
+            return None
+        candidate = f"https://{candidate}"
+
+    try:
+        parsed = urlsplit(candidate)
+    except ValueError:
+        return None
+    if parsed.scheme not in {"http", "https", "chrome", "file"}:
+        return None
+    if parsed.scheme in {"http", "https"} and not parsed.hostname:
+        return None
+
+    hostname = parsed.hostname or ""
+    host = hostname.lower()
+    if ":" in host:
+        host = f"[{host}]"
+    try:
+        port = parsed.port
+    except ValueError:
+        return None
+    if port is not None:
+        host = f"{host}:{port}"
+    # Deliberately discard username/password from the normalized URL.
+    netloc = host
+    return urlunsplit((parsed.scheme.lower(), netloc, parsed.path, parsed.query, parsed.fragment))

--- a/src/openchronicle/capture/scheduler.py
+++ b/src/openchronicle/capture/scheduler.py
@@ -4,11 +4,13 @@ from __future__ import annotations
 
 import asyncio
 import contextlib
+import fcntl
 import hashlib
 import json
 import queue
 import threading
 import time
+import uuid
 from collections.abc import Callable
 from datetime import UTC, datetime
 from pathlib import Path
@@ -20,7 +22,7 @@ from ..logger import get
 from ..store import fts as fts_store
 from . import ax_capture, s1_parser, screenshot, window_meta
 from .event_dispatcher import EventDispatcher
-from .signal_store import SignalStore
+from .signal_store import CAPTURE_SCHEMA_VERSION, SignalStore
 from .watcher import AXWatcherProcess
 
 logger = get("openchronicle.capture")
@@ -35,6 +37,32 @@ _AX_RETRY_EVENTS = {
 _AX_RETRY_DELAYS = (0.15, 0.35)
 
 
+class CaptureDaemonAlreadyRunning(RuntimeError):
+    """Raised when another capture daemon owns the same data root."""
+
+
+class _CaptureDaemonLock:
+    def __init__(self) -> None:
+        self._handle: Any = None
+
+    def acquire(self) -> None:
+        paths.ensure_dirs()
+        self._handle = paths.capture_daemon_lock_file().open("a+")
+        try:
+            fcntl.flock(self._handle.fileno(), fcntl.LOCK_EX | fcntl.LOCK_NB)
+        except BlockingIOError as exc:
+            self._handle.close()
+            self._handle = None
+            raise CaptureDaemonAlreadyRunning("already_running") from exc
+
+    def release(self) -> None:
+        if self._handle is None:
+            return
+        fcntl.flock(self._handle.fileno(), fcntl.LOCK_UN)
+        self._handle.close()
+        self._handle = None
+
+
 def _now_iso() -> str:
     return datetime.now(UTC).astimezone().isoformat(timespec="milliseconds")
 
@@ -47,22 +75,41 @@ def _normalize_title(value: Any) -> str:
     return " ".join(str(value or "").split())
 
 
-def _snapshot_window_meta(ax_tree: dict[str, Any]) -> dict[str, str]:
+def _snapshot_window_meta(ax_tree: dict[str, Any]) -> dict[str, Any]:
     apps = ax_tree.get("apps") or []
     app = next((item for item in apps if item.get("is_frontmost")), None)
     if app is None:
         app = apps[0] if apps else None
     if not isinstance(app, dict):
-        return {"app_name": "", "title": "", "bundle_id": ""}
+        return {
+            "app_name": "",
+            "title": "",
+            "bundle_id": "",
+            "pid": 0,
+            "window_identity": "",
+            "window_identity_confidence": "low",
+        }
 
     windows = app.get("windows") or []
     window = next((item for item in windows if item.get("focused")), None)
     if window is None:
         window = windows[0] if windows else None
+    bundle_id = str(app.get("bundle_id") or "")
+    pid = app.get("pid") if isinstance(app.get("pid"), int) else 0
+    window_number = window.get("window_number") if isinstance(window, dict) else None
+    if isinstance(window_number, int):
+        window_identity = f"{bundle_id}:{pid}:{window_number}"
+        confidence = "high"
+    else:
+        window_identity = f"{bundle_id}:{pid}" if bundle_id else ""
+        confidence = "low"
     return {
         "app_name": _normalize_title(app.get("name")),
         "title": _normalize_title(window.get("title")) if isinstance(window, dict) else "",
-        "bundle_id": str(app.get("bundle_id") or ""),
+        "bundle_id": bundle_id,
+        "pid": pid,
+        "window_identity": window_identity,
+        "window_identity_confidence": confidence,
     }
 
 
@@ -166,10 +213,18 @@ def _build_capture(
         logger.info("capture skipped (paused)")
         return None
 
+    excluded_bundles = set(cfg.excluded_signal_bundle_ids)
+    if excluded_bundles:
+        active = window_meta.active_window()
+        if active.bundle_id in excluded_bundles:
+            logger.info("capture skipped (privacy excluded app)")
+            return None
+
     ts = _now_iso()
     out: dict[str, Any] = {
         "timestamp": ts,
         "schema_version": 2,
+        "capture_schema_version": CAPTURE_SCHEMA_VERSION,
         "trigger": trigger or {"event_type": "heartbeat"},
     }
 
@@ -187,6 +242,9 @@ def _build_capture(
 
     snapshot_meta = _snapshot_window_meta(out.get("ax_tree") or {})
     bundle_id = snapshot_meta["bundle_id"]
+    if bundle_id in excluded_bundles:
+        logger.info("capture skipped (privacy excluded AX snapshot)")
+        return None
     app_name = snapshot_meta["app_name"]
     title = snapshot_meta["title"]
     title_source = "ax_snapshot" if title else "unavailable"
@@ -217,6 +275,9 @@ def _build_capture(
         "bundle_id": bundle_id,
         "title_source": title_source,
         "sampled_at": ts,
+        "pid": snapshot_meta["pid"],
+        "window_identity": snapshot_meta["window_identity"],
+        "window_identity_confidence": snapshot_meta["window_identity_confidence"],
     }
 
     if cfg.include_screenshot:
@@ -238,7 +299,7 @@ def _build_capture(
 def _write_capture(out: dict[str, Any]) -> Path:
     """Persist a built capture dict to the buffer, index it for search, and log."""
     ts = out["timestamp"]
-    path = paths.capture_buffer_dir() / f"{_safe_filename(ts)}.json"
+    path = paths.capture_buffer_dir() / f"{_safe_filename(ts)}-{uuid.uuid4().hex}.json"
     path.write_text(json.dumps(out, ensure_ascii=False))
     _index_capture(path.stem, out)
     meta = out.get("window_meta") or {}
@@ -377,6 +438,13 @@ class _CaptureRunner:
         )
         self._worker.start()
 
+    def context_snapshot_ref(self, bundle_id: str) -> str | None:
+        """Return the latest same-app Snapshot ref for key-down-time context."""
+        with self._lock:
+            if bundle_id and bundle_id == self._last_snapshot_bundle:
+                return self._last_snapshot_ref
+            return None
+
     def stop_worker(self, *, timeout: float = 5.0) -> None:
         """Drain the queue and join the worker thread."""
         if self._worker is None:
@@ -395,25 +463,52 @@ class _CaptureRunner:
                 return
             self.run(item)
 
-    def run(self, trigger: dict[str, Any] | None) -> None:
+    def run(self, trigger: dict[str, Any] | None) -> dict[str, Any]:
         # Serialize so two near-simultaneous triggers don't double-capture.
         with self._lock:
-            signal_id = str((trigger or {}).get("signal_id") or "")
+            capture_trigger = dict(trigger or {})
+            completion = capture_trigger.pop("_capture_complete", None)
+            signal_id = str(capture_trigger.get("signal_id") or "")
+            context_snapshot_ref = self._last_snapshot_ref
+            outcome: dict[str, Any]
             try:
-                out = _build_capture(self._cfg, self._provider, trigger)
+                out = _build_capture(self._cfg, self._provider, capture_trigger)
                 if out is None:
-                    self._update_signal(signal_id, "capture_unavailable")
-                    return
+                    outcome = {
+                        "status": "capture_unavailable",
+                        "quality_status": "degraded",
+                        "error_reason": "capture_unavailable",
+                        "context_snapshot_ref": context_snapshot_ref,
+                    }
+                    self._finish_capture(signal_id, outcome, completion)
+                    return outcome
                 meta = out.get("window_meta") or {}
                 snapshot_bundle = str(meta.get("bundle_id") or "")
-                trigger_bundle = str((trigger or {}).get("bundle_id") or "")
+                trigger_bundle = str(capture_trigger.get("bundle_id") or "")
+                trigger_window = str(capture_trigger.get("window_identity") or "")
+                snapshot_window = str(meta.get("window_identity") or "")
+                trigger_confidence = str(
+                    capture_trigger.get("window_identity_confidence") or "low"
+                )
                 if signal_id and (
                     not trigger_bundle
                     or not snapshot_bundle
                     or trigger_bundle != snapshot_bundle
+                    or (
+                        trigger_confidence == "high"
+                        and trigger_window
+                        and snapshot_window
+                        and trigger_window != snapshot_window
+                    )
                 ):
-                    self._update_signal(signal_id, "app_changed")
-                    return
+                    outcome = {
+                        "status": "app_changed",
+                        "quality_status": "failed",
+                        "error_reason": "bundle_changed",
+                        "context_snapshot_ref": context_snapshot_ref,
+                    }
+                    self._finish_capture(signal_id, outcome, completion)
+                    return outcome
                 fingerprint = _content_fingerprint(out)
                 if fingerprint == self._last_fingerprint:
                     logger.debug(
@@ -427,38 +522,100 @@ class _CaptureRunner:
                         and self._last_snapshot_ref
                         and snapshot_bundle == self._last_snapshot_bundle
                     ):
-                        self._update_signal(
-                            signal_id, "reused", snapshot_ref=self._last_snapshot_ref
-                        )
+                        outcome = {
+                            "status": "reused",
+                            "quality_status": "good",
+                            "snapshot_ref": self._last_snapshot_ref,
+                            "context_snapshot_ref": context_snapshot_ref,
+                        }
                     else:
-                        self._update_signal(signal_id, "duplicate_without_ref")
-                    return
+                        outcome = {
+                            "status": "unchanged",
+                            "quality_status": "degraded",
+                            "error_reason": "duplicate_without_ref",
+                            "context_snapshot_ref": context_snapshot_ref,
+                        }
+                    self._finish_capture(signal_id, outcome, completion)
+                    return outcome
                 self._last_fingerprint = fingerprint
                 path = _write_capture(out)
                 self._last_snapshot_ref = path.name
                 self._last_snapshot_bundle = snapshot_bundle
-                self._update_signal(signal_id, "captured", snapshot_ref=path.name)
+                outcome = {
+                    "status": "new",
+                    "quality_status": "good",
+                    "snapshot_ref": path.name,
+                    "context_snapshot_ref": context_snapshot_ref,
+                }
+                self._finish_capture(signal_id, outcome, completion)
                 if self._pre_capture_hook is not None and trigger is not None:
                     try:
                         self._pre_capture_hook(trigger)
                     except Exception as exc:  # noqa: BLE001
                         logger.warning("pre_capture_hook failed: %s", exc)
+                return outcome
             except Exception as exc:  # noqa: BLE001
-                self._update_signal(signal_id, "capture_failed")
+                outcome = {
+                    "status": "unresolved",
+                    "quality_status": "failed",
+                    "error_reason": type(exc).__name__,
+                    "context_snapshot_ref": context_snapshot_ref,
+                }
+                self._finish_capture(signal_id, outcome, completion)
                 logger.error("capture failed: %s", exc, exc_info=True)
+                return outcome
 
     def run_threaded(self, trigger: dict[str, Any] | None) -> None:
         """Enqueue a capture for the worker thread; drop with a warning if full."""
+        trigger_data = trigger or {}
+        excluded_bundles = set(self._cfg.excluded_signal_bundle_ids)
+        if (
+            trigger is not None
+            and not trigger_data.get("signal_id")
+            and excluded_bundles
+            and window_meta.active_window().bundle_id in excluded_bundles
+        ):
+            # A stale event from another app can arrive after the user switches
+            # into an excluded app. Drop it before queueing so capture logging
+            # cannot cause a Terminal AXValueChanged feedback loop. Signal-
+            # linked requests still run so their attempt ledger is finalized.
+            return
         try:
             self._queue.put_nowait(trigger)
         except queue.Full:
             signal_id = str((trigger or {}).get("signal_id") or "")
-            self._update_signal(signal_id, "queue_full")
+            completion = (trigger or {}).get("_capture_complete")
+            outcome = {
+                "status": "deferred_queue_full",
+                "quality_status": "failed",
+                "error_reason": "queue_full",
+            }
+            self._finish_capture(signal_id, outcome, completion)
             logger.warning(
                 "capture queue full (%d pending); dropping trigger=%s",
                 self._queue.qsize(),
                 (trigger or {}).get("event_type") if trigger else "heartbeat",
             )
+
+    def _finish_capture(
+        self,
+        signal_id: str,
+        outcome: dict[str, Any],
+        completion: Any,
+    ) -> None:
+        if callable(completion):
+            completion(outcome)
+            return
+        compatibility = {
+            "new": "captured",
+            "reused": "reused",
+            "unchanged": "duplicate_without_ref",
+            "deferred_queue_full": "queue_full",
+            "app_changed": "app_changed",
+            "capture_unavailable": "capture_unavailable",
+            "unresolved": "capture_failed",
+        }
+        self._update_signal(signal_id, compatibility.get(str(outcome.get("status")), "capture_failed"), snapshot_ref=outcome.get("snapshot_ref"))
 
     def _update_signal(
         self,
@@ -492,6 +649,8 @@ async def run_forever(
     timer isn't refreshed by a screen that isn't changing (e.g. the lock
     screen overnight).
     """
+    daemon_lock = _CaptureDaemonLock()
+    daemon_lock.acquire()
     provider = ax_capture.create_provider(
         depth=cfg.ax_depth,
         timeout=cfg.ax_timeout_seconds,
@@ -503,6 +662,12 @@ async def run_forever(
         logger.warning("AX capture unavailable: %s", getattr(provider, "reason", "unknown reason"))
 
     signal_store = SignalStore(excluded_bundle_ids=set(cfg.excluded_signal_bundle_ids))
+    recoverable_signal_ids = signal_store.recover_incomplete()
+    if recoverable_signal_ids:
+        logger.info(
+            "signal recovery candidates deferred until context verification: count=%d",
+            len(recoverable_signal_ids),
+        )
     runner = _CaptureRunner(
         cfg,
         provider,
@@ -519,11 +684,14 @@ async def run_forever(
         runner.run_threaded(trigger)
 
     if cfg.event_driven:
-        watcher = AXWatcherProcess()
+        watcher = AXWatcherProcess(
+            excluded_bundle_ids=set(cfg.excluded_signal_bundle_ids),
+        )
         if watcher.available:
             dispatcher = EventDispatcher(
                 _on_capture,
                 signal_store=signal_store,
+                context_snapshot_ref_fn=runner.context_snapshot_ref,
                 debounce_seconds=cfg.debounce_seconds,
                 min_capture_gap_seconds=cfg.min_capture_gap_seconds,
                 dedup_interval_seconds=cfg.dedup_interval_seconds,
@@ -531,6 +699,10 @@ async def run_forever(
             )
             watcher.on_event(dispatcher.on_event)
             watcher.start()
+            for signal_id in recoverable_signal_ids:
+                signal = signal_store.read(signal_id)
+                if signal is not None:
+                    dispatcher.recover_signal(signal)
             logger.info("event-driven capture started")
         else:
             logger.warning("AX watcher unavailable — falling back to heartbeat-only captures")
@@ -568,6 +740,7 @@ async def run_forever(
         if dispatcher is not None:
             dispatcher.shutdown()
         runner.stop_worker()
+        daemon_lock.release()
 
 
 def cleanup_buffer(

--- a/src/openchronicle/capture/scheduler.py
+++ b/src/openchronicle/capture/scheduler.py
@@ -20,6 +20,7 @@ from ..logger import get
 from ..store import fts as fts_store
 from . import ax_capture, s1_parser, screenshot, window_meta
 from .event_dispatcher import EventDispatcher
+from .signal_store import SignalStore
 from .watcher import AXWatcherProcess
 
 logger = get("openchronicle.capture")
@@ -29,12 +30,13 @@ _AX_RETRY_EVENTS = {
     "AXFocusedWindowChanged",
     "UserMouseClick",
     "UserTextInput",
+    "UserEnter",
 }
 _AX_RETRY_DELAYS = (0.15, 0.35)
 
 
 def _now_iso() -> str:
-    return datetime.now(UTC).astimezone().replace(microsecond=0).isoformat()
+    return datetime.now(UTC).astimezone().isoformat(timespec="milliseconds")
 
 
 def _safe_filename(ts: str) -> str:
@@ -350,13 +352,17 @@ class _CaptureRunner:
         cfg: CaptureConfig,
         provider: ax_capture.AXProvider,
         *,
+        signal_store: SignalStore | None = None,
         pre_capture_hook: Callable[[dict[str, Any]], None] | None = None,
     ) -> None:
         self._cfg = cfg
         self._provider = provider
+        self._signal_store = signal_store
         self._pre_capture_hook = pre_capture_hook
         self._lock = threading.Lock()
         self._last_fingerprint: str | None = None
+        self._last_snapshot_ref: str | None = None
+        self._last_snapshot_bundle: str = ""
         self._queue: queue.Queue[Any] = queue.Queue(maxsize=self._MAX_PENDING)
         self._worker: threading.Thread | None = None
 
@@ -392,28 +398,53 @@ class _CaptureRunner:
     def run(self, trigger: dict[str, Any] | None) -> None:
         # Serialize so two near-simultaneous triggers don't double-capture.
         with self._lock:
+            signal_id = str((trigger or {}).get("signal_id") or "")
             try:
                 out = _build_capture(self._cfg, self._provider, trigger)
                 if out is None:
+                    self._update_signal(signal_id, "capture_unavailable")
+                    return
+                meta = out.get("window_meta") or {}
+                snapshot_bundle = str(meta.get("bundle_id") or "")
+                trigger_bundle = str((trigger or {}).get("bundle_id") or "")
+                if signal_id and (
+                    not trigger_bundle
+                    or not snapshot_bundle
+                    or trigger_bundle != snapshot_bundle
+                ):
+                    self._update_signal(signal_id, "app_changed")
                     return
                 fingerprint = _content_fingerprint(out)
                 if fingerprint == self._last_fingerprint:
-                    meta = out.get("window_meta") or {}
                     logger.debug(
                         "capture skipped (content dedup): trigger=%s app=%r title=%r",
                         (trigger or {}).get("event_type"),
                         meta.get("app_name"),
                         (meta.get("title") or "")[:60],
                     )
+                    if (
+                        signal_id
+                        and self._last_snapshot_ref
+                        and snapshot_bundle == self._last_snapshot_bundle
+                    ):
+                        self._update_signal(
+                            signal_id, "reused", snapshot_ref=self._last_snapshot_ref
+                        )
+                    else:
+                        self._update_signal(signal_id, "duplicate_without_ref")
                     return
                 self._last_fingerprint = fingerprint
-                _write_capture(out)
+                path = _write_capture(out)
+                self._last_snapshot_ref = path.name
+                self._last_snapshot_bundle = snapshot_bundle
+                self._update_signal(signal_id, "captured", snapshot_ref=path.name)
                 if self._pre_capture_hook is not None and trigger is not None:
                     try:
                         self._pre_capture_hook(trigger)
                     except Exception as exc:  # noqa: BLE001
                         logger.warning("pre_capture_hook failed: %s", exc)
             except Exception as exc:  # noqa: BLE001
+                self._update_signal(signal_id, "capture_failed")
                 logger.error("capture failed: %s", exc, exc_info=True)
 
     def run_threaded(self, trigger: dict[str, Any] | None) -> None:
@@ -421,10 +452,26 @@ class _CaptureRunner:
         try:
             self._queue.put_nowait(trigger)
         except queue.Full:
+            signal_id = str((trigger or {}).get("signal_id") or "")
+            self._update_signal(signal_id, "queue_full")
             logger.warning(
                 "capture queue full (%d pending); dropping trigger=%s",
                 self._queue.qsize(),
                 (trigger or {}).get("event_type") if trigger else "heartbeat",
+            )
+
+    def _update_signal(
+        self,
+        signal_id: str,
+        status: str,
+        *,
+        snapshot_ref: str | None = None,
+    ) -> None:
+        if signal_id and self._signal_store is not None:
+            self._signal_store.update_snapshot(
+                signal_id,
+                status=status,
+                snapshot_ref=snapshot_ref,
             )
 
 
@@ -455,7 +502,13 @@ async def run_forever(
     if not provider.available:
         logger.warning("AX capture unavailable: %s", getattr(provider, "reason", "unknown reason"))
 
-    runner = _CaptureRunner(cfg, provider, pre_capture_hook=pre_capture_hook)
+    signal_store = SignalStore(excluded_bundle_ids=set(cfg.excluded_signal_bundle_ids))
+    runner = _CaptureRunner(
+        cfg,
+        provider,
+        signal_store=signal_store,
+        pre_capture_hook=pre_capture_hook,
+    )
     runner.start_worker()
     watcher: AXWatcherProcess | None = None
     dispatcher: EventDispatcher | None = None
@@ -470,6 +523,7 @@ async def run_forever(
         if watcher.available:
             dispatcher = EventDispatcher(
                 _on_capture,
+                signal_store=signal_store,
                 debounce_seconds=cfg.debounce_seconds,
                 min_capture_gap_seconds=cfg.min_capture_gap_seconds,
                 dedup_interval_seconds=cfg.dedup_interval_seconds,

--- a/src/openchronicle/capture/scheduler.py
+++ b/src/openchronicle/capture/scheduler.py
@@ -24,6 +24,14 @@ from .watcher import AXWatcherProcess
 
 logger = get("openchronicle.capture")
 
+_AX_RETRY_EVENTS = {
+    "AXApplicationActivated",
+    "AXFocusedWindowChanged",
+    "UserMouseClick",
+    "UserTextInput",
+}
+_AX_RETRY_DELAYS = (0.15, 0.35)
+
 
 def _now_iso() -> str:
     return datetime.now(UTC).astimezone().replace(microsecond=0).isoformat()
@@ -31,6 +39,117 @@ def _now_iso() -> str:
 
 def _safe_filename(ts: str) -> str:
     return ts.replace(":", "-").replace("+", "p")
+
+
+def _normalize_title(value: Any) -> str:
+    return " ".join(str(value or "").split())
+
+
+def _snapshot_window_meta(ax_tree: dict[str, Any]) -> dict[str, str]:
+    apps = ax_tree.get("apps") or []
+    app = next((item for item in apps if item.get("is_frontmost")), None)
+    if app is None:
+        app = apps[0] if apps else None
+    if not isinstance(app, dict):
+        return {"app_name": "", "title": "", "bundle_id": ""}
+
+    windows = app.get("windows") or []
+    window = next((item for item in windows if item.get("focused")), None)
+    if window is None:
+        window = windows[0] if windows else None
+    return {
+        "app_name": _normalize_title(app.get("name")),
+        "title": _normalize_title(window.get("title")) if isinstance(window, dict) else "",
+        "bundle_id": str(app.get("bundle_id") or ""),
+    }
+
+
+def _frontmost_snapshot_app(ax_tree: dict[str, Any]) -> dict[str, Any] | None:
+    apps = ax_tree.get("apps") or []
+    app = next((item for item in apps if item.get("is_frontmost")), None)
+    if app is None:
+        app = apps[0] if apps else None
+    return app if isinstance(app, dict) else None
+
+
+def _snapshot_quality(ax_tree: dict[str, Any]) -> int:
+    """Score fields that indicate the focused app's AX tree is ready."""
+    app = _frontmost_snapshot_app(ax_tree)
+    if app is None:
+        return 0
+
+    score = 1
+    if app.get("focused_element"):
+        score += 100
+    windows = app.get("windows") or []
+    focused_window = next((item for item in windows if item.get("focused")), None)
+    if isinstance(focused_window, dict):
+        score += 10
+        if _normalize_title(focused_window.get("title")):
+            score += 2
+        if focused_window.get("elements"):
+            score += 5
+    return score
+
+
+def _snapshot_needs_retry(ax_tree: dict[str, Any], trigger: dict[str, Any] | None) -> bool:
+    if (trigger or {}).get("event_type") not in _AX_RETRY_EVENTS:
+        return False
+    app = _frontmost_snapshot_app(ax_tree)
+    if app is None or app.get("focused_element"):
+        return False
+    # Browser page content often has no focused AX element at all. If the
+    # focused window already exposes one unambiguous address-bar URL, the
+    # snapshot is useful and complete; retrying only adds 500 ms of latency.
+    url, source = s1_parser._extract_url(app)
+    if url is not None and source == "ax_address_bar":
+        return False
+    return any(window.get("focused") for window in (app.get("windows") or []))
+
+
+def _capture_ax_with_retry(
+    provider: ax_capture.AXProvider,
+    trigger: dict[str, Any] | None,
+) -> tuple[ax_capture.AXCaptureResult | None, int, bool]:
+    """Capture AX, retrying incomplete snapshots without crossing app identity."""
+    result = provider.capture_frontmost(focused_window_only=True)
+    if result is None:
+        return None, 0, True
+
+    best = result
+    best_quality = _snapshot_quality(result.raw_json)
+    initial_bundle = _snapshot_window_meta(result.raw_json)["bundle_id"]
+    retry_count = 0
+    consistent = True
+
+    if not _snapshot_needs_retry(result.raw_json, trigger):
+        return best, retry_count, consistent
+
+    for delay in _AX_RETRY_DELAYS:
+        time.sleep(delay)
+        candidate = provider.capture_frontmost(focused_window_only=True)
+        retry_count += 1
+        if candidate is None:
+            continue
+
+        candidate_bundle = _snapshot_window_meta(candidate.raw_json)["bundle_id"]
+        if initial_bundle and candidate_bundle != initial_bundle:
+            consistent = False
+            logger.debug(
+                "AX retry discarded after app changed: %r -> %r",
+                initial_bundle,
+                candidate_bundle,
+            )
+            break
+
+        quality = _snapshot_quality(candidate.raw_json)
+        if quality > best_quality:
+            best = candidate
+            best_quality = quality
+        if not _snapshot_needs_retry(candidate.raw_json, trigger):
+            break
+
+    return best, retry_count, consistent
 
 
 def _build_capture(
@@ -52,20 +171,51 @@ def _build_capture(
         "trigger": trigger or {"event_type": "heartbeat"},
     }
 
-    meta = window_meta.active_window()
-    out["window_meta"] = {
-        "app_name": meta.app_name,
-        "title": meta.title,
-        "bundle_id": meta.bundle_id,
-    }
-
     if provider.available:
-        result = provider.capture_frontmost(focused_window_only=True)
+        result, retry_count, ax_consistent = _capture_ax_with_retry(provider, trigger)
         if result is not None:
             out["ax_tree"] = result.raw_json
-            out["ax_metadata"] = result.metadata
+            out["ax_metadata"] = {
+                **result.metadata,
+                "retry_count": retry_count,
+                "app_consistent": ax_consistent,
+            }
     else:
         out["ax_unavailable"] = True
+
+    snapshot_meta = _snapshot_window_meta(out.get("ax_tree") or {})
+    bundle_id = snapshot_meta["bundle_id"]
+    app_name = snapshot_meta["app_name"]
+    title = snapshot_meta["title"]
+    title_source = "ax_snapshot" if title else "unavailable"
+
+    trigger_data = trigger or {}
+    trigger_bundle = str(trigger_data.get("bundle_id") or "")
+    trigger_title = _normalize_title(trigger_data.get("window_title"))
+    if not title and trigger_title and trigger_bundle and trigger_bundle == bundle_id:
+        title = trigger_title
+        title_source = "trigger"
+
+    # System Events is a last-resort metadata source. Only combine it with an
+    # AX snapshot when both identify the same app.
+    if not app_name or not bundle_id or not title:
+        fallback = window_meta.active_window()
+        if not bundle_id:
+            bundle_id = fallback.bundle_id
+        if not app_name and (not bundle_id or fallback.bundle_id == bundle_id):
+            app_name = _normalize_title(fallback.app_name)
+        if not title and fallback.bundle_id == bundle_id:
+            title = _normalize_title(fallback.title)
+            if title:
+                title_source = "system_events"
+
+    out["window_meta"] = {
+        "app_name": app_name,
+        "title": title,
+        "bundle_id": bundle_id,
+        "title_source": title_source,
+        "sampled_at": ts,
+    }
 
     if cfg.include_screenshot:
         shot = screenshot.grab(
@@ -215,7 +365,9 @@ class _CaptureRunner:
         if self._worker is not None and self._worker.is_alive():
             return
         self._worker = threading.Thread(
-            target=self._worker_loop, name="capture-worker", daemon=True,
+            target=self._worker_loop,
+            name="capture-worker",
+            daemon=True,
         )
         self._worker.start()
 
@@ -293,11 +445,15 @@ async def run_forever(
     timer isn't refreshed by a screen that isn't changing (e.g. the lock
     screen overnight).
     """
-    provider = ax_capture.create_provider(depth=cfg.ax_depth, timeout=cfg.ax_timeout_seconds)
+    provider = ax_capture.create_provider(
+        depth=cfg.ax_depth,
+        timeout=cfg.ax_timeout_seconds,
+        manual_accessibility_bundles=(
+            cfg.electron_accessibility_bundles if cfg.enable_electron_accessibility else []
+        ),
+    )
     if not provider.available:
-        logger.warning(
-            "AX capture unavailable: %s", getattr(provider, "reason", "unknown reason")
-        )
+        logger.warning("AX capture unavailable: %s", getattr(provider, "reason", "unknown reason"))
 
     runner = _CaptureRunner(cfg, provider, pre_capture_hook=pre_capture_hook)
     runner.start_worker()
@@ -323,9 +479,7 @@ async def run_forever(
             watcher.start()
             logger.info("event-driven capture started")
         else:
-            logger.warning(
-                "AX watcher unavailable — falling back to heartbeat-only captures"
-            )
+            logger.warning("AX watcher unavailable — falling back to heartbeat-only captures")
 
     # One capture immediately so the user sees something in the buffer right away.
     runner.run_threaded(None)
@@ -335,7 +489,8 @@ async def run_forever(
             heartbeat_interval = max(60.0, cfg.heartbeat_minutes * 60.0)
             logger.info(
                 "heartbeat capture every %.0fs (event_driven=%s)",
-                heartbeat_interval, cfg.event_driven,
+                heartbeat_interval,
+                cfg.event_driven,
             )
             while True:
                 await asyncio.sleep(heartbeat_interval)
@@ -462,9 +617,7 @@ def _delete_captures_from_fts(stems: list[str]) -> None:
             for stem in stems:
                 fts_store.delete_capture(conn, stem)
     except Exception as exc:  # noqa: BLE001
-        logger.warning(
-            "captures FTS delete failed for %d stems: %s", len(stems), exc
-        )
+        logger.warning("captures FTS delete failed for %d stems: %s", len(stems), exc)
 
 
 def _strip_screenshot_inplace(path: Path) -> bool:

--- a/src/openchronicle/capture/signal_store.py
+++ b/src/openchronicle/capture/signal_store.py
@@ -1,0 +1,170 @@
+"""Durable, privacy-minimized storage for physical user interaction signals."""
+
+from __future__ import annotations
+
+import json
+import os
+import re
+import threading
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+from .. import paths
+from ..logger import get
+
+logger = get("openchronicle.capture")
+
+_SAFE_TARGET_FIELDS = ("role", "subrole", "identifier")
+_SAFE_MODIFIERS = {"shift", "command", "control", "option"}
+_SAFE_KEY_VARIANTS = {"return", "keypad_enter"}
+_SAFE_SIGNAL_ID = re.compile(r"[A-Za-z0-9_-]{1,128}\Z")
+_SNAPSHOT_STATUS_RANK = {
+    "pending": 0,
+    "capture_request_failed": 1,
+    "capture_unavailable": 1,
+    "capture_failed": 1,
+    "queue_full": 1,
+    "app_changed": 1,
+    "duplicate_without_ref": 1,
+    "reused": 2,
+    "captured": 3,
+}
+
+
+@dataclass(frozen=True)
+class SignalCreateResult:
+    created: bool
+    signal_id: str
+    path: Path | None = None
+
+
+def sanitize_user_enter(
+    raw: dict[str, Any],
+    *,
+    excluded_bundle_ids: set[str] | None = None,
+) -> dict[str, Any] | None:
+    """Return the allowlisted UserEnter representation, or ``None`` if excluded."""
+    if raw.get("event_type") != "UserEnter":
+        return None
+
+    signal_id = str(raw.get("signal_id") or "").strip()
+    if not _SAFE_SIGNAL_ID.fullmatch(signal_id):
+        return None
+
+    bundle_id = str(raw.get("bundle_id") or "")[:300]
+    if bundle_id and bundle_id in (excluded_bundle_ids or set()):
+        return None
+
+    target = raw.get("input_target")
+    safe_target: dict[str, str] | None = None
+    if isinstance(target, dict):
+        candidate = {
+            key: str(target[key])[:200]
+            for key in _SAFE_TARGET_FIELDS
+            if target.get(key)
+        }
+        if candidate:
+            safe_target = candidate
+
+    status = str(raw.get("input_target_status") or "")
+    if status not in {"available", "ax_unavailable", "secure_input", "app_unavailable"}:
+        status = "available" if safe_target else "ax_unavailable"
+    if status == "secure_input":
+        safe_target = None
+
+    key_variant = str(raw.get("key_variant") or "")
+    if key_variant not in _SAFE_KEY_VARIANTS:
+        key_variant = "return"
+
+    modifiers = raw.get("modifiers")
+    safe_modifiers = (
+        [str(item) for item in modifiers if str(item) in _SAFE_MODIFIERS]
+        if isinstance(modifiers, list)
+        else []
+    )
+
+    pid = raw.get("pid")
+    safe_pid = pid if isinstance(pid, int) and pid >= 0 else 0
+    return {
+        "schema_version": 1,
+        "signal_id": signal_id,
+        "event_type": "UserEnter",
+        "timestamp": str(raw.get("timestamp") or "")[:80],
+        "pid": safe_pid,
+        "app_name": str(raw.get("app_name") or "")[:200],
+        "bundle_id": bundle_id,
+        # Window titles can contain document names, contacts, URLs, or typed
+        # secrets. They are deliberately not persisted in lightweight signals.
+        "window_title": "",
+        "key_variant": key_variant,
+        "modifiers": safe_modifiers,
+        "input_target": safe_target,
+        "input_target_status": status,
+        "semantic_intent": "unknown",
+        "snapshot_status": "pending",
+        "snapshot_ref": None,
+    }
+
+
+class SignalStore:
+    """Atomic, idempotent JSON-file store keyed by watcher ``signal_id``."""
+
+    def __init__(self, *, excluded_bundle_ids: set[str] | None = None) -> None:
+        self._excluded_bundle_ids = excluded_bundle_ids or set()
+        self._lock = threading.Lock()
+
+    def create_user_enter(self, raw: dict[str, Any]) -> SignalCreateResult:
+        signal = sanitize_user_enter(raw, excluded_bundle_ids=self._excluded_bundle_ids)
+        if signal is None:
+            return SignalCreateResult(False, str(raw.get("signal_id") or ""))
+
+        paths.ensure_dirs()
+        signal_id = signal["signal_id"]
+        target = paths.signal_buffer_dir() / f"{signal_id}.json"
+        with self._lock:
+            if target.exists():
+                return SignalCreateResult(False, signal_id, target)
+            self._atomic_write(target, signal)
+        logger.info(
+            "signal stored: id=%s type=UserEnter bundle=%r",
+            signal_id,
+            signal["bundle_id"],
+        )
+        return SignalCreateResult(True, signal_id, target)
+
+    def update_snapshot(
+        self,
+        signal_id: str,
+        *,
+        status: str,
+        snapshot_ref: str | None = None,
+    ) -> None:
+        target = paths.signal_buffer_dir() / f"{signal_id}.json"
+        with self._lock:
+            if not target.exists():
+                return
+            try:
+                signal = json.loads(target.read_text())
+            except (OSError, json.JSONDecodeError):
+                logger.warning("signal update failed: id=%s status=unreadable", signal_id)
+                return
+            current_status = str(signal.get("snapshot_status") or "pending")
+            if _SNAPSHOT_STATUS_RANK.get(status, 1) < _SNAPSHOT_STATUS_RANK.get(
+                current_status, 0
+            ):
+                return
+            signal["snapshot_status"] = status
+            signal["snapshot_ref"] = snapshot_ref
+            self._atomic_write(target, signal)
+        logger.info("signal updated: id=%s snapshot_status=%s", signal_id, status)
+
+    @staticmethod
+    def _atomic_write(target: Path, payload: dict[str, Any]) -> None:
+        temp = target.with_name(f".{target.name}.{os.getpid()}.tmp")
+        try:
+            temp.write_text(json.dumps(payload, ensure_ascii=False))
+            temp.replace(target)
+        finally:
+            if temp.exists():
+                temp.unlink()

--- a/src/openchronicle/capture/signal_store.py
+++ b/src/openchronicle/capture/signal_store.py
@@ -1,4 +1,4 @@
-"""Durable, privacy-minimized storage for physical user interaction signals."""
+"""Durable, privacy-minimized storage for physical interaction signals."""
 
 from __future__ import annotations
 
@@ -6,7 +6,9 @@ import json
 import os
 import re
 import threading
+import uuid
 from dataclasses import dataclass
+from datetime import UTC, datetime
 from pathlib import Path
 from typing import Any
 
@@ -15,21 +17,27 @@ from ..logger import get
 
 logger = get("openchronicle.capture")
 
+SIGNAL_SCHEMA_VERSION = 2
+CAPTURE_SCHEMA_VERSION = 2
+PRIVACY_POLICY_VERSION = 1
+EVENT_SCHEMA_VERSION = 1
+
 _SAFE_TARGET_FIELDS = ("role", "subrole", "identifier")
 _SAFE_MODIFIERS = {"shift", "command", "control", "option"}
 _SAFE_KEY_VARIANTS = {"return", "keypad_enter"}
-_SAFE_SIGNAL_ID = re.compile(r"[A-Za-z0-9_-]{1,128}\Z")
-_SNAPSHOT_STATUS_RANK = {
-    "pending": 0,
-    "capture_request_failed": 1,
-    "capture_unavailable": 1,
-    "capture_failed": 1,
-    "queue_full": 1,
-    "app_changed": 1,
-    "duplicate_without_ref": 1,
-    "reused": 2,
-    "captured": 3,
+_SAFE_ID = re.compile(r"[A-Za-z0-9_-]{1,128}\Z")
+_CONTROL_CHARACTERS = re.compile(r"[\x00-\x1f\x7f]")
+_SUCCESS_STATES = {"new", "reused", "unchanged"}
+_TERMINAL_STATES = _SUCCESS_STATES | {
+    "unresolved",
+    "app_changed",
+    "privacy_blocked",
 }
+_DEFERRED_STATES = {"pending", "running", "deferred_queue_full", "deferred_shutdown"}
+
+
+def _now_iso() -> str:
+    return datetime.now(UTC).astimezone().isoformat(timespec="milliseconds")
 
 
 @dataclass(frozen=True)
@@ -39,17 +47,42 @@ class SignalCreateResult:
     path: Path | None = None
 
 
+@dataclass(frozen=True)
+class EventCreateResult:
+    created: bool
+    event_id: str
+    path: Path | None = None
+
+
+@dataclass(frozen=True)
+class LinkageUpdateResult:
+    updated: bool
+    signal_id: str
+    revision: int | None = None
+    status: str | None = None
+
+
+def _sanitize_identifier(value: Any) -> str:
+    identifier = str(value or "")
+    if not identifier or len(identifier) > 128 or _CONTROL_CHARACTERS.search(identifier):
+        return ""
+    # Identifiers should be structural labels, not dynamic user content.
+    if len(identifier.split()) > 8 or "\n" in identifier or "\r" in identifier:
+        return ""
+    return identifier
+
+
 def sanitize_user_enter(
     raw: dict[str, Any],
     *,
     excluded_bundle_ids: set[str] | None = None,
 ) -> dict[str, Any] | None:
-    """Return the allowlisted UserEnter representation, or ``None`` if excluded."""
+    """Return the allowlisted V2 UserEnter representation, or ``None``."""
     if raw.get("event_type") != "UserEnter":
         return None
 
     signal_id = str(raw.get("signal_id") or "").strip()
-    if not _SAFE_SIGNAL_ID.fullmatch(signal_id):
+    if not _SAFE_ID.fullmatch(signal_id):
         return None
 
     bundle_id = str(raw.get("bundle_id") or "")[:300]
@@ -59,11 +92,17 @@ def sanitize_user_enter(
     target = raw.get("input_target")
     safe_target: dict[str, str] | None = None
     if isinstance(target, dict):
-        candidate = {
-            key: str(target[key])[:200]
-            for key in _SAFE_TARGET_FIELDS
-            if target.get(key)
-        }
+        candidate: dict[str, str] = {}
+        for key in _SAFE_TARGET_FIELDS:
+            if not target.get(key):
+                continue
+            value = (
+                _sanitize_identifier(target[key])
+                if key == "identifier"
+                else str(target[key])[:80]
+            )
+            if value:
+                candidate[key] = value
         if candidate:
             safe_target = candidate
 
@@ -76,43 +115,126 @@ def sanitize_user_enter(
     key_variant = str(raw.get("key_variant") or "")
     if key_variant not in _SAFE_KEY_VARIANTS:
         key_variant = "return"
-
     modifiers = raw.get("modifiers")
     safe_modifiers = (
         [str(item) for item in modifiers if str(item) in _SAFE_MODIFIERS]
         if isinstance(modifiers, list)
         else []
     )
-
     pid = raw.get("pid")
     safe_pid = pid if isinstance(pid, int) and pid >= 0 else 0
+    correlation_id = str(raw.get("correlation_id") or signal_id)
+    if not _SAFE_ID.fullmatch(correlation_id):
+        correlation_id = signal_id
+    window_identity = str(raw.get("window_identity") or "")[:200]
+    window_confidence = str(raw.get("window_identity_confidence") or "low")
+    if window_confidence not in {"high", "medium", "low"}:
+        window_confidence = "low"
+
     return {
-        "schema_version": 1,
+        "signal_schema_version": SIGNAL_SCHEMA_VERSION,
+        "privacy_policy_version": PRIVACY_POLICY_VERSION,
         "signal_id": signal_id,
+        "correlation_id": correlation_id,
         "event_type": "UserEnter",
         "timestamp": str(raw.get("timestamp") or "")[:80],
         "pid": safe_pid,
         "app_name": str(raw.get("app_name") or "")[:200],
         "bundle_id": bundle_id,
-        # Window titles can contain document names, contacts, URLs, or typed
-        # secrets. They are deliberately not persisted in lightweight signals.
-        "window_title": "",
         "key_variant": key_variant,
         "modifiers": safe_modifiers,
         "input_target": safe_target,
         "input_target_status": status,
+        "window_identity": window_identity,
+        "window_identity_confidence": window_confidence,
         "semantic_intent": "unknown",
-        "snapshot_status": "pending",
-        "snapshot_ref": None,
+        "context_snapshot_ref": raw.get("context_snapshot_ref"),
+        "result_snapshot_ref": None,
+        "post_capture_status": "pending",
+        "quality_status": None,
+        "capture_request_id": None,
+        "capture_attempts": [],
+        "correlation_deadline": raw.get("correlation_deadline"),
+        "revision": 1,
+        "created_at": _now_iso(),
+        "updated_at": _now_iso(),
+    }
+
+
+def sanitize_user_text_input(
+    raw: dict[str, Any],
+    *,
+    excluded_bundle_ids: set[str] | None = None,
+) -> dict[str, Any] | None:
+    """Return a relationship-only UserTextInput event without typed content."""
+    if raw.get("event_type") != "UserTextInput":
+        return None
+    event_id = str(raw.get("event_id") or "").strip()
+    correlation_id = str(raw.get("correlation_id") or "").strip()
+    related_signal_id = str(raw.get("related_signal_id") or "").strip()
+    if not all(
+        _SAFE_ID.fullmatch(value)
+        for value in (event_id, correlation_id, related_signal_id)
+    ):
+        return None
+    bundle_id = str(raw.get("bundle_id") or "")[:300]
+    if bundle_id and bundle_id in (excluded_bundle_ids or set()):
+        return None
+    details = raw.get("details")
+    safe_details: dict[str, Any] = {}
+    if isinstance(details, dict):
+        reason = str(details.get("reason") or "")[:80]
+        if reason:
+            safe_details["reason"] = reason
+        element = details.get("element")
+        if isinstance(element, dict):
+            safe_element: dict[str, str] = {}
+            for key in _SAFE_TARGET_FIELDS:
+                if not element.get(key):
+                    continue
+                value = (
+                    _sanitize_identifier(element[key])
+                    if key == "identifier"
+                    else str(element[key])[:80]
+                )
+                if value:
+                    safe_element[key] = value
+            if safe_element:
+                safe_details["element"] = safe_element
+    return {
+        "event_schema_version": EVENT_SCHEMA_VERSION,
+        "privacy_policy_version": PRIVACY_POLICY_VERSION,
+        "event_id": event_id,
+        "event_type": "UserTextInput",
+        "correlation_id": correlation_id,
+        "related_signal_id": related_signal_id,
+        "timestamp": str(raw.get("timestamp") or "")[:80],
+        "pid": raw.get("pid") if isinstance(raw.get("pid"), int) else 0,
+        "app_name": str(raw.get("app_name") or "")[:200],
+        "bundle_id": bundle_id,
+        "details": safe_details,
+        "created_at": _now_iso(),
     }
 
 
 class SignalStore:
-    """Atomic, idempotent JSON-file store keyed by watcher ``signal_id``."""
+    """Atomic, idempotent V2 JSON store keyed by watcher ``signal_id``."""
 
     def __init__(self, *, excluded_bundle_ids: set[str] | None = None) -> None:
         self._excluded_bundle_ids = excluded_bundle_ids or set()
-        self._lock = threading.Lock()
+        self._locks_guard = threading.Lock()
+        self._signal_locks: dict[str, threading.RLock] = {}
+
+    @property
+    def excluded_bundle_ids(self) -> frozenset[str]:
+        return frozenset(self._excluded_bundle_ids)
+
+    def is_excluded_bundle(self, bundle_id: str) -> bool:
+        return bool(bundle_id and bundle_id in self._excluded_bundle_ids)
+
+    def _signal_lock(self, signal_id: str) -> threading.RLock:
+        with self._locks_guard:
+            return self._signal_locks.setdefault(signal_id, threading.RLock())
 
     def create_user_enter(self, raw: dict[str, Any]) -> SignalCreateResult:
         signal = sanitize_user_enter(raw, excluded_bundle_ids=self._excluded_bundle_ids)
@@ -122,7 +244,7 @@ class SignalStore:
         paths.ensure_dirs()
         signal_id = signal["signal_id"]
         target = paths.signal_buffer_dir() / f"{signal_id}.json"
-        with self._lock:
+        with self._signal_lock(signal_id):
             if target.exists():
                 return SignalCreateResult(False, signal_id, target)
             self._atomic_write(target, signal)
@@ -133,6 +255,255 @@ class SignalStore:
         )
         return SignalCreateResult(True, signal_id, target)
 
+    def create_user_text_input(self, raw: dict[str, Any]) -> EventCreateResult:
+        event = sanitize_user_text_input(
+            raw,
+            excluded_bundle_ids=self._excluded_bundle_ids,
+        )
+        if event is None:
+            return EventCreateResult(False, str(raw.get("event_id") or ""))
+        paths.ensure_dirs()
+        event_id = event["event_id"]
+        target = paths.event_buffer_dir() / f"{event_id}.json"
+        with self._signal_lock(f"event-{event_id}"):
+            if target.exists():
+                return EventCreateResult(False, event_id, target)
+            self._atomic_write(target, event)
+        logger.info(
+            "event stored: id=%s type=UserTextInput bundle=%r",
+            event_id,
+            event["bundle_id"],
+        )
+        return EventCreateResult(True, event_id, target)
+
+    def read(self, signal_id: str) -> dict[str, Any] | None:
+        if not _SAFE_ID.fullmatch(signal_id):
+            return None
+        target = paths.signal_buffer_dir() / f"{signal_id}.json"
+        with self._signal_lock(signal_id):
+            return self._read_current(target)
+
+    def update_linkage(
+        self,
+        signal_id: str,
+        *,
+        attempt: dict[str, Any] | None = None,
+        post_capture_status: str | None = None,
+        quality_status: str | None = None,
+        result_snapshot_ref: str | None = None,
+        context_snapshot_ref: str | None = None,
+        capture_request_id: str | None = None,
+        expected_revision: int | None = None,
+    ) -> LinkageUpdateResult:
+        """Merge one linkage update under the per-signal lock.
+
+        The latest file is always re-read after locking. Attempts are idempotent
+        by ``attempt_id`` and successful terminal results cannot be downgraded.
+        """
+        if not _SAFE_ID.fullmatch(signal_id):
+            return LinkageUpdateResult(False, signal_id)
+        target = paths.signal_buffer_dir() / f"{signal_id}.json"
+        with self._signal_lock(signal_id):
+            signal = self._read_current(target)
+            if signal is None:
+                return LinkageUpdateResult(False, signal_id)
+            if signal.get("signal_schema_version") != SIGNAL_SCHEMA_VERSION:
+                logger.warning("signal update skipped: id=%s status=unsupported_schema", signal_id)
+                return LinkageUpdateResult(False, signal_id)
+
+            current_revision = int(signal.get("revision") or 0)
+            if expected_revision is not None and expected_revision != current_revision:
+                logger.debug(
+                    "signal revision changed: id=%s expected=%d actual=%d; merging latest",
+                    signal_id,
+                    expected_revision,
+                    current_revision,
+                )
+
+            changed = False
+            if capture_request_id and signal.get("capture_request_id") != capture_request_id:
+                signal["capture_request_id"] = capture_request_id
+                changed = True
+            if (
+                context_snapshot_ref is not None
+                and signal.get("context_snapshot_ref") is None
+            ):
+                signal["context_snapshot_ref"] = context_snapshot_ref
+                changed = True
+
+            if attempt is not None:
+                clean_attempt = self._sanitize_attempt(attempt)
+                if clean_attempt is not None:
+                    attempts = signal.setdefault("capture_attempts", [])
+                    existing = next(
+                        (
+                            item
+                            for item in attempts
+                            if item.get("attempt_id") == clean_attempt["attempt_id"]
+                        ),
+                        None,
+                    )
+                    if existing is None:
+                        attempts.append(clean_attempt)
+                        changed = True
+                    else:
+                        for key, value in clean_attempt.items():
+                            if value is None:
+                                continue
+                            if existing.get(key) != value:
+                                existing[key] = value
+                                changed = True
+
+            current_status = str(signal.get("post_capture_status") or "pending")
+            requested_status = post_capture_status
+            if requested_status and self._transition_allowed(current_status, requested_status):
+                if requested_status != current_status:
+                    signal["post_capture_status"] = requested_status
+                    changed = True
+                if result_snapshot_ref is not None and signal.get(
+                    "result_snapshot_ref"
+                ) != result_snapshot_ref:
+                    signal["result_snapshot_ref"] = result_snapshot_ref
+                    changed = True
+                if quality_status in {"good", "degraded", "failed"} and signal.get(
+                    "quality_status"
+                ) != quality_status:
+                    signal["quality_status"] = quality_status
+                    changed = True
+            elif requested_status and requested_status != current_status:
+                logger.warning(
+                    "signal transition rejected: id=%s from=%s to=%s",
+                    signal_id,
+                    current_status,
+                    requested_status,
+                )
+
+            if not changed:
+                return LinkageUpdateResult(False, signal_id, current_revision, current_status)
+            signal["revision"] = current_revision + 1
+            signal["updated_at"] = _now_iso()
+            self._atomic_write(target, signal)
+            final_status = str(signal.get("post_capture_status") or "")
+
+        logger.info("signal updated: id=%s post_capture_status=%s", signal_id, final_status)
+        return LinkageUpdateResult(True, signal_id, current_revision + 1, final_status)
+
+    def defer_pending_for_shutdown(self) -> int:
+        """Mark unfinished V2 attempts as shutdown-deferred without downgrading success."""
+        count = 0
+        for target in paths.signal_buffer_dir().glob("*.json"):
+            signal_id = target.stem
+            signal = self.read(signal_id)
+            if not signal or signal.get("post_capture_status") in _TERMINAL_STATES:
+                continue
+            attempt = {
+                "attempt_id": f"shutdown-{uuid.uuid4().hex}",
+                "capture_request_id": signal.get("capture_request_id"),
+                "phase": "primary",
+                "association_mode": "direct",
+                "status": "cancelled_shutdown",
+                "completed_at": _now_iso(),
+                "quality_status": "failed",
+                "error_reason": "shutdown",
+            }
+            result = self.update_linkage(
+                signal_id,
+                attempt=attempt,
+                post_capture_status="deferred_shutdown",
+                quality_status="failed",
+            )
+            count += int(result.updated)
+        return count
+
+    def recover_incomplete(self) -> list[str]:
+        """Normalize abandoned V2 work before the watcher starts.
+
+        Live recapture is intentionally left to the dispatcher, which can
+        verify the current app/window. Unknown and legacy schemas are never
+        modified here.
+        """
+        recoverable: list[str] = []
+        paths.ensure_dirs()
+        for target in paths.signal_buffer_dir().glob("*.json"):
+            try:
+                signal = json.loads(target.read_text())
+            except (OSError, json.JSONDecodeError):
+                continue
+            if (
+                signal.get("signal_schema_version") is None
+                and signal.get("schema_version") == 1
+            ):
+                signal = self._migrate_v1(target, signal)
+            if signal.get("signal_schema_version") != SIGNAL_SCHEMA_VERSION:
+                logger.warning("signal recovery skipped: file=%s status=unsupported_schema", target.name)
+                continue
+            status = str(signal.get("post_capture_status") or "")
+            if status not in _DEFERRED_STATES:
+                continue
+            if status == "running":
+                self.update_linkage(
+                    str(signal["signal_id"]),
+                    attempt={
+                        "attempt_id": f"abandoned-{uuid.uuid4().hex}",
+                        "phase": "recovery",
+                        "association_mode": "recovery",
+                        "status": "abandoned_process_exit",
+                        "completed_at": _now_iso(),
+                        "quality_status": "failed",
+                        "error_reason": "process_exit",
+                    },
+                    post_capture_status="deferred_shutdown",
+                    quality_status="failed",
+                )
+            if not signal.get("result_snapshot_ref"):
+                recoverable.append(str(signal["signal_id"]))
+        return recoverable
+
+    def _migrate_v1(self, target: Path, legacy: dict[str, Any]) -> dict[str, Any]:
+        """Atomically and idempotently migrate the known first-round schema."""
+        signal_id = str(legacy.get("signal_id") or "")
+        if not _SAFE_ID.fullmatch(signal_id):
+            return legacy
+        with self._signal_lock(signal_id):
+            current = self._read_current(target)
+            if current is None:
+                return legacy
+            if current.get("signal_schema_version") == SIGNAL_SCHEMA_VERSION:
+                return current
+            if current.get("schema_version") != 1:
+                return current
+            raw = {
+                **current,
+                "correlation_id": signal_id,
+                "context_snapshot_ref": None,
+            }
+            migrated = sanitize_user_enter(
+                raw,
+                excluded_bundle_ids=self._excluded_bundle_ids,
+            )
+            if migrated is None:
+                return current
+            old_status = str(current.get("snapshot_status") or "pending")
+            status_map = {
+                "captured": "new",
+                "reused": "reused",
+                "duplicate_without_ref": "unchanged",
+                "queue_full": "deferred_queue_full",
+                "pending": "pending",
+                "app_changed": "app_changed",
+            }
+            migrated["post_capture_status"] = status_map.get(old_status, "unresolved")
+            old_ref = current.get("snapshot_ref")
+            if migrated["post_capture_status"] in _SUCCESS_STATES:
+                migrated["result_snapshot_ref"] = old_ref
+                migrated["quality_status"] = "good"
+            elif migrated["post_capture_status"] == "deferred_queue_full":
+                migrated["quality_status"] = "failed"
+            migrated["migrated_from_schema_version"] = 1
+            self._atomic_write(target, migrated)
+            logger.info("signal migrated: id=%s from=1 to=%d", signal_id, SIGNAL_SCHEMA_VERSION)
+            return migrated
+
     def update_snapshot(
         self,
         signal_id: str,
@@ -140,28 +511,83 @@ class SignalStore:
         status: str,
         snapshot_ref: str | None = None,
     ) -> None:
-        target = paths.signal_buffer_dir() / f"{signal_id}.json"
-        with self._lock:
-            if not target.exists():
-                return
-            try:
-                signal = json.loads(target.read_text())
-            except (OSError, json.JSONDecodeError):
-                logger.warning("signal update failed: id=%s status=unreadable", signal_id)
-                return
-            current_status = str(signal.get("snapshot_status") or "pending")
-            if _SNAPSHOT_STATUS_RANK.get(status, 1) < _SNAPSHOT_STATUS_RANK.get(
-                current_status, 0
-            ):
-                return
-            signal["snapshot_status"] = status
-            signal["snapshot_ref"] = snapshot_ref
-            self._atomic_write(target, signal)
-        logger.info("signal updated: id=%s snapshot_status=%s", signal_id, status)
+        """Compatibility wrapper for V1 callers while the pipeline uses V2."""
+        mapping = {
+            "captured": ("new", "good"),
+            "reused": ("reused", "good"),
+            "duplicate_without_ref": ("unchanged", "degraded"),
+            "queue_full": ("deferred_queue_full", "failed"),
+            "capture_request_failed": ("unresolved", "failed"),
+            "capture_unavailable": ("unresolved", "failed"),
+            "capture_failed": ("unresolved", "failed"),
+            "app_changed": ("app_changed", "failed"),
+        }
+        post_status, quality = mapping.get(status, ("unresolved", "failed"))
+        self.update_linkage(
+            signal_id,
+            post_capture_status=post_status,
+            quality_status=quality,
+            result_snapshot_ref=snapshot_ref,
+        )
+
+    @staticmethod
+    def _transition_allowed(current: str, requested: str) -> bool:
+        known = _TERMINAL_STATES | _DEFERRED_STATES
+        if requested not in known:
+            return False
+        if current in _SUCCESS_STATES:
+            return requested in _SUCCESS_STATES
+        if current in {"app_changed", "privacy_blocked", "unresolved"}:
+            return requested == current
+        return True
+
+    @staticmethod
+    def _sanitize_attempt(raw: dict[str, Any]) -> dict[str, Any] | None:
+        attempt_id = str(raw.get("attempt_id") or "")
+        if not _SAFE_ID.fullmatch(attempt_id):
+            return None
+        capture_request_id = str(raw.get("capture_request_id") or "")
+        if capture_request_id and not _SAFE_ID.fullmatch(capture_request_id):
+            return None
+        phase = str(raw.get("phase") or "")
+        if phase not in {"primary", "natural_event", "follow_up", "recovery"}:
+            return None
+        association_mode = str(raw.get("association_mode") or "direct")
+        if association_mode not in {"direct", "coalesced", "reused", "recovery"}:
+            association_mode = "direct"
+        return {
+            "attempt_id": attempt_id,
+            "capture_request_id": capture_request_id or None,
+            "phase": phase,
+            "association_mode": association_mode,
+            "requested_at": str(raw.get("requested_at") or "")[:80] or None,
+            "due_at": str(raw.get("due_at") or "")[:80] or None,
+            "started_at": str(raw.get("started_at") or "")[:80] or None,
+            "completed_at": str(raw.get("completed_at") or "")[:80] or None,
+            "bundle_id": str(raw.get("bundle_id") or "")[:300],
+            "window_identity": str(raw.get("window_identity") or "")[:200],
+            "window_identity_confidence": str(
+                raw.get("window_identity_confidence") or "low"
+            ),
+            "status": str(raw.get("status") or "")[:80],
+            "snapshot_ref": str(raw.get("snapshot_ref") or "")[:300] or None,
+            "quality_status": str(raw.get("quality_status") or "")[:40] or None,
+            "error_reason": str(raw.get("error_reason") or "")[:120] or None,
+        }
+
+    @staticmethod
+    def _read_current(target: Path) -> dict[str, Any] | None:
+        if not target.exists():
+            return None
+        try:
+            value = json.loads(target.read_text())
+        except (OSError, json.JSONDecodeError):
+            return None
+        return value if isinstance(value, dict) else None
 
     @staticmethod
     def _atomic_write(target: Path, payload: dict[str, Any]) -> None:
-        temp = target.with_name(f".{target.name}.{os.getpid()}.tmp")
+        temp = target.with_name(f".{target.name}.{os.getpid()}.{uuid.uuid4().hex}.tmp")
         try:
             temp.write_text(json.dumps(payload, ensure_ascii=False))
             temp.replace(target)

--- a/src/openchronicle/capture/watcher.py
+++ b/src/openchronicle/capture/watcher.py
@@ -22,6 +22,7 @@ from typing import Any
 
 from ..logger import get
 from .ax_capture import _maybe_compile
+from .signal_store import PRIVACY_POLICY_VERSION
 
 logger = get("openchronicle.capture")
 
@@ -73,12 +74,20 @@ class AXWatcherProcess:
     The callback runs on the reader thread — keep it fast and thread-safe.
     """
 
-    def __init__(self, *, max_reconnect_delay: float = 60.0) -> None:
+    def __init__(
+        self,
+        *,
+        excluded_bundle_ids: set[str] | None = None,
+        privacy_policy_version: int = PRIVACY_POLICY_VERSION,
+        max_reconnect_delay: float = 60.0,
+    ) -> None:
         self._watcher_path = _resolve_watcher_path()
         self._callback: Callable[[dict[str, Any]], None] | None = None
         self._process: subprocess.Popen | None = None
         self._reader_thread: threading.Thread | None = None
         self._stop_event = threading.Event()
+        self._excluded_bundle_ids = sorted(excluded_bundle_ids or set())
+        self._privacy_policy_version = privacy_policy_version
         self._max_reconnect_delay = max_reconnect_delay
 
     @property
@@ -157,8 +166,15 @@ class AXWatcherProcess:
         if not self._watcher_path:
             return
         try:
+            command = [
+                str(self._watcher_path),
+                "--privacy-policy-version",
+                str(self._privacy_policy_version),
+            ]
+            for bundle_id in self._excluded_bundle_ids:
+                command.extend(["--exclude-bundle", bundle_id])
             self._process = subprocess.Popen(
-                [str(self._watcher_path)],
+                command,
                 stdout=subprocess.PIPE,
                 stderr=subprocess.DEVNULL,
                 text=True,
@@ -197,6 +213,9 @@ class AXWatcherProcess:
             rc = self._process.wait()
             if rc == 2:
                 logger.error("Accessibility permission not granted — watcher won't restart")
+                self._stop_event.set()
+            elif rc == 3:
+                logger.error("Watcher privacy policy unavailable — refusing unsafe restart")
                 self._stop_event.set()
             elif rc != 0:
                 logger.warning("AX watcher exited with code %d", rc)

--- a/src/openchronicle/cli.py
+++ b/src/openchronicle/cli.py
@@ -880,7 +880,13 @@ def capture_once() -> None:
     from .capture import ax_capture, scheduler
 
     provider = ax_capture.create_provider(
-        depth=cfg.capture.ax_depth, timeout=cfg.capture.ax_timeout_seconds
+        depth=cfg.capture.ax_depth,
+        timeout=cfg.capture.ax_timeout_seconds,
+        manual_accessibility_bundles=(
+            cfg.capture.electron_accessibility_bundles
+            if cfg.capture.enable_electron_accessibility
+            else []
+        ),
     )
     path = scheduler.capture_once(cfg.capture, provider)
     if path:

--- a/src/openchronicle/config.py
+++ b/src/openchronicle/config.py
@@ -55,6 +55,9 @@ class CaptureConfig:
             "com.microsoft.VSCode",
         ]
     )
+    # User interaction signals from these apps are discarded before disk/log
+    # persistence. Bundle IDs are exact matches.
+    excluded_signal_bundle_ids: list[str] = field(default_factory=list)
 
 
 @dataclass
@@ -255,6 +258,8 @@ screenshot_jpeg_quality = 80
 ax_depth = 100                # Electron apps (Claude Desktop, VS Code, Slack) have deep DOM; 8 only reaches the chrome
 ax_timeout_seconds = 3
 enable_electron_accessibility = true
+# Exact bundle IDs whose UserEnter signals must be discarded before persistence.
+excluded_signal_bundle_ids = []
 electron_accessibility_bundles = ["com.microsoft.VSCode"]
 
 [timeline]

--- a/src/openchronicle/config.py
+++ b/src/openchronicle/config.py
@@ -28,7 +28,9 @@ class CaptureConfig:
     debounce_seconds: float = 3.0  # for AXValueChanged bursts
     min_capture_gap_seconds: float = 2.0  # between consecutive captures
     dedup_interval_seconds: float = 1.0  # per-event-type dedup window
-    same_window_dedup_seconds: float = 5.0  # skip repeat non-focus capture in same window within this window
+    same_window_dedup_seconds: float = (
+        5.0  # skip repeat non-focus capture in same window within this window
+    )
     # Legacy timer knob (kept for back-compat; also treated as a floor on heartbeat)
     interval_minutes: int = 10
     # Tiered buffer retention:
@@ -47,6 +49,12 @@ class CaptureConfig:
     screenshot_jpeg_quality: int = 80
     ax_depth: int = 100
     ax_timeout_seconds: int = 3
+    enable_electron_accessibility: bool = True
+    electron_accessibility_bundles: list[str] = field(
+        default_factory=lambda: [
+            "com.microsoft.VSCode",
+        ]
+    )
 
 
 @dataclass
@@ -122,8 +130,10 @@ class SearchConfig:
 
 @dataclass
 class MCPConfig:
-    auto_start: bool = True               # run an in-daemon MCP server
-    transport: str = "streamable-http"    # "streamable-http" | "sse" (deprecated 2026-04-01) | "stdio"
+    auto_start: bool = True  # run an in-daemon MCP server
+    transport: str = (
+        "streamable-http"  # "streamable-http" | "sse" (deprecated 2026-04-01) | "stdio"
+    )
     host: str = "127.0.0.1"
     port: int = 8742
 
@@ -161,7 +171,9 @@ def _as_dict(section: Any) -> dict:
 def _build_models(raw: dict) -> dict[str, ModelConfig]:
     # Build default first so stage sections can inherit only its explicitly-set values.
     default_data = _as_dict(raw.get("default", {}))
-    default_allowed = {k: v for k, v in default_data.items() if k in ModelConfig.__dataclass_fields__}
+    default_allowed = {
+        k: v for k, v in default_data.items() if k in ModelConfig.__dataclass_fields__
+    }
     default = ModelConfig(**default_allowed)
     models = {"default": default}
     for name, section in raw.items():
@@ -242,6 +254,8 @@ screenshot_max_width = 1920
 screenshot_jpeg_quality = 80
 ax_depth = 100                # Electron apps (Claude Desktop, VS Code, Slack) have deep DOM; 8 only reaches the chrome
 ax_timeout_seconds = 3
+enable_electron_accessibility = true
+electron_accessibility_bundles = ["com.microsoft.VSCode"]
 
 [timeline]
 window_minutes = 1             # length of each aggregator block (verbatim-preserving normalizer)

--- a/src/openchronicle/paths.py
+++ b/src/openchronicle/paths.py
@@ -25,6 +25,10 @@ def signal_buffer_dir() -> Path:
     return root() / "signal-buffer"
 
 
+def event_buffer_dir() -> Path:
+    return root() / "event-buffer"
+
+
 def logs_dir() -> Path:
     return root() / "logs"
 
@@ -41,6 +45,10 @@ def pid_file() -> Path:
     return root() / ".pid"
 
 
+def capture_daemon_lock_file() -> Path:
+    return root() / ".capture-daemon.lock"
+
+
 def paused_flag() -> Path:
     return root() / ".paused"
 
@@ -51,5 +59,12 @@ def writer_state() -> Path:
 
 
 def ensure_dirs() -> None:
-    for d in (root(), memory_dir(), capture_buffer_dir(), signal_buffer_dir(), logs_dir()):
+    for d in (
+        root(),
+        memory_dir(),
+        capture_buffer_dir(),
+        signal_buffer_dir(),
+        event_buffer_dir(),
+        logs_dir(),
+    ):
         d.mkdir(parents=True, exist_ok=True)

--- a/src/openchronicle/paths.py
+++ b/src/openchronicle/paths.py
@@ -21,6 +21,10 @@ def capture_buffer_dir() -> Path:
     return root() / "capture-buffer"
 
 
+def signal_buffer_dir() -> Path:
+    return root() / "signal-buffer"
+
+
 def logs_dir() -> Path:
     return root() / "logs"
 
@@ -47,5 +51,5 @@ def writer_state() -> Path:
 
 
 def ensure_dirs() -> None:
-    for d in (root(), memory_dir(), capture_buffer_dir(), logs_dir()):
+    for d in (root(), memory_dir(), capture_buffer_dir(), signal_buffer_dir(), logs_dir()):
         d.mkdir(parents=True, exist_ok=True)

--- a/tests/test_ax_capture.py
+++ b/tests/test_ax_capture.py
@@ -1,0 +1,81 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from types import SimpleNamespace
+
+from openchronicle.capture import ax_capture
+
+
+def test_provider_passes_manual_accessibility_bundle_and_reports_result(
+    monkeypatch,
+) -> None:
+    calls: list[list[str]] = []
+
+    def fake_run(args, **kwargs):
+        calls.append(args)
+        return SimpleNamespace(
+            returncode=0,
+            stderr="",
+            stdout=json.dumps(
+                {
+                    "timestamp": "2026-07-24T14:00:00+08:00",
+                    "apps": [
+                        {
+                            "name": "Code",
+                            "bundle_id": "com.microsoft.VSCode",
+                            "is_frontmost": True,
+                            "manual_accessibility": {
+                                "requested": True,
+                                "succeeded": True,
+                                "error_code": 0,
+                            },
+                            "windows": [
+                                {
+                                    "title": "Untitled-1",
+                                    "focused": True,
+                                    "elements": [],
+                                }
+                            ],
+                        }
+                    ],
+                }
+            ),
+        )
+
+    monkeypatch.setattr(ax_capture.subprocess, "run", fake_run)
+    provider = ax_capture.MacAXHelperProvider(
+        helper_path=Path("/tmp/mac-ax-helper"),
+        depth=100,
+        timeout=3,
+        manual_accessibility_bundles=[
+            "com.microsoft.VSCode",
+            "com.example.CustomElectron",
+        ],
+    )
+
+    result = provider.capture_frontmost()
+
+    assert result is not None
+    assert calls == [
+        [
+            "/tmp/mac-ax-helper",
+            "--focused-window-only",
+            "--manual-accessibility-bundle",
+            "com.microsoft.VSCode",
+            "--manual-accessibility-bundle",
+            "com.example.CustomElectron",
+            "--depth",
+            "100",
+            "--timeout",
+            "3",
+        ]
+    ]
+    assert result.metadata["manual_accessibility"] == [
+        {
+            "bundle_id": "com.microsoft.VSCode",
+            "requested": True,
+            "succeeded": True,
+            "error_code": 0,
+        }
+    ]

--- a/tests/test_capture_metadata.py
+++ b/tests/test_capture_metadata.py
@@ -1,8 +1,10 @@
 from __future__ import annotations
 
+import json
 from dataclasses import dataclass
 
 from openchronicle.capture import scheduler
+from openchronicle.capture.signal_store import SignalStore
 from openchronicle.config import CaptureConfig
 
 
@@ -328,3 +330,102 @@ def test_build_capture_does_not_retry_complete_browser_page(monkeypatch, ac_root
     assert out["url"] == "https://example.com/?oc_case=A01"
     assert out["ax_metadata"]["retry_count"] == 0
     assert out["ax_metadata"]["app_consistent"] is True
+
+
+def test_enter_reuses_identical_snapshot_without_losing_signal(monkeypatch, ac_root) -> None:
+    monkeypatch.setattr(scheduler, "_AX_RETRY_DELAYS", ())
+    monkeypatch.setattr(scheduler.screenshot, "grab", lambda **_: None)
+    provider = _Provider(
+        {
+            "apps": [
+                {
+                    "name": "TextEdit",
+                    "bundle_id": "com.apple.TextEdit",
+                    "is_frontmost": True,
+                    "focused_element": {"role": "AXTextArea", "value": "same"},
+                    "windows": [
+                        {
+                            "title": "Untitled",
+                            "focused": True,
+                            "elements": [{"role": "AXTextArea", "value": "same"}],
+                        }
+                    ],
+                }
+            ]
+        }
+    )
+    store = SignalStore()
+    runner = scheduler._CaptureRunner(
+        CaptureConfig(include_screenshot=False),
+        provider,
+        signal_store=store,
+    )
+    for signal_id in ("enter-1", "enter-2"):
+        store.create_user_enter(
+            {
+                "event_type": "UserEnter",
+                "signal_id": signal_id,
+                "timestamp": "2026-07-25T12:00:00+08:00",
+                "bundle_id": "com.apple.TextEdit",
+                "key_variant": "return",
+            }
+        )
+        runner.run(
+            {
+                "event_type": "UserEnter",
+                "signal_id": signal_id,
+                "bundle_id": "com.apple.TextEdit",
+            }
+        )
+
+    first = json.loads((ac_root / "signal-buffer" / "enter-1.json").read_text())
+    second = json.loads((ac_root / "signal-buffer" / "enter-2.json").read_text())
+    assert first["snapshot_status"] == "captured"
+    assert second["snapshot_status"] == "reused"
+    assert second["snapshot_ref"] == first["snapshot_ref"]
+    assert len(list((ac_root / "capture-buffer").glob("*.json"))) == 1
+
+
+def test_enter_does_not_associate_snapshot_after_app_switch(monkeypatch, ac_root) -> None:
+    monkeypatch.setattr(scheduler, "_AX_RETRY_DELAYS", ())
+    monkeypatch.setattr(scheduler.screenshot, "grab", lambda **_: None)
+    provider = _Provider(
+        {
+            "apps": [
+                {
+                    "name": "Chrome",
+                    "bundle_id": "com.google.Chrome",
+                    "is_frontmost": True,
+                    "windows": [{"title": "New app", "focused": True, "elements": []}],
+                }
+            ]
+        }
+    )
+    store = SignalStore()
+    store.create_user_enter(
+        {
+            "event_type": "UserEnter",
+            "signal_id": "switched",
+            "timestamp": "2026-07-25T12:00:00+08:00",
+            "bundle_id": "com.apple.TextEdit",
+            "key_variant": "return",
+        }
+    )
+    runner = scheduler._CaptureRunner(
+        CaptureConfig(include_screenshot=False),
+        provider,
+        signal_store=store,
+    )
+
+    runner.run(
+        {
+            "event_type": "UserEnter",
+            "signal_id": "switched",
+            "bundle_id": "com.apple.TextEdit",
+        }
+    )
+
+    signal = json.loads((ac_root / "signal-buffer" / "switched.json").read_text())
+    assert signal["snapshot_status"] == "app_changed"
+    assert signal["snapshot_ref"] is None
+    assert list((ac_root / "capture-buffer").glob("*.json")) == []

--- a/tests/test_capture_metadata.py
+++ b/tests/test_capture_metadata.py
@@ -3,6 +3,8 @@ from __future__ import annotations
 import json
 from dataclasses import dataclass
 
+import pytest
+
 from openchronicle.capture import scheduler
 from openchronicle.capture.signal_store import SignalStore
 from openchronicle.config import CaptureConfig
@@ -26,6 +28,54 @@ class _Provider:
         index = min(self.calls, len(self.snapshots) - 1)
         self.calls += 1
         return _Result(self.snapshots[index], {})
+
+
+def test_capture_daemon_singleton_lock(ac_root) -> None:
+    first = scheduler._CaptureDaemonLock()
+    second = scheduler._CaptureDaemonLock()
+    first.acquire()
+    try:
+        with pytest.raises(scheduler.CaptureDaemonAlreadyRunning, match="already_running"):
+            second.acquire()
+    finally:
+        first.release()
+
+
+def test_excluded_frontmost_app_is_blocked_at_capture_time(monkeypatch, ac_root) -> None:
+    provider = _Provider(
+        {
+            "apps": [
+                {
+                    "name": "TextEdit",
+                    "bundle_id": "com.apple.TextEdit",
+                    "is_frontmost": True,
+                    "windows": [{"title": "Private", "focused": True, "elements": []}],
+                }
+            ]
+        }
+    )
+    monkeypatch.setattr(
+        scheduler.window_meta,
+        "active_window",
+        lambda: scheduler.window_meta.WindowMeta(
+            app_name="TextEdit",
+            title="Private",
+            bundle_id="com.apple.TextEdit",
+        ),
+    )
+
+    out = scheduler._build_capture(
+        CaptureConfig(
+            include_screenshot=False,
+            excluded_signal_bundle_ids=["com.apple.TextEdit"],
+        ),
+        provider,
+        {"event_type": "UserMouseClick", "bundle_id": "com.apple.dock"},
+    )
+
+    assert out is None
+    assert provider.calls == 0
+    assert list((ac_root / "capture-buffer").glob("*.json")) == []
 
 
 def test_build_capture_prefers_snapshot_title(monkeypatch, ac_root) -> None:
@@ -380,9 +430,9 @@ def test_enter_reuses_identical_snapshot_without_losing_signal(monkeypatch, ac_r
 
     first = json.loads((ac_root / "signal-buffer" / "enter-1.json").read_text())
     second = json.loads((ac_root / "signal-buffer" / "enter-2.json").read_text())
-    assert first["snapshot_status"] == "captured"
-    assert second["snapshot_status"] == "reused"
-    assert second["snapshot_ref"] == first["snapshot_ref"]
+    assert first["post_capture_status"] == "new"
+    assert second["post_capture_status"] == "reused"
+    assert second["result_snapshot_ref"] == first["result_snapshot_ref"]
     assert len(list((ac_root / "capture-buffer").glob("*.json"))) == 1
 
 
@@ -426,6 +476,29 @@ def test_enter_does_not_associate_snapshot_after_app_switch(monkeypatch, ac_root
     )
 
     signal = json.loads((ac_root / "signal-buffer" / "switched.json").read_text())
-    assert signal["snapshot_status"] == "app_changed"
-    assert signal["snapshot_ref"] is None
+    assert signal["post_capture_status"] == "app_changed"
+    assert signal["result_snapshot_ref"] is None
     assert list((ac_root / "capture-buffer").glob("*.json")) == []
+
+
+def test_excluded_frontmost_app_is_dropped_before_capture_queue(
+    monkeypatch, ac_root
+) -> None:
+    runner = scheduler._CaptureRunner(
+        CaptureConfig(excluded_signal_bundle_ids=["com.apple.TextEdit"]),
+        _Provider({"apps": []}),
+    )
+    monkeypatch.setattr(
+        scheduler.window_meta,
+        "active_window",
+        lambda: type("ActiveWindow", (), {"bundle_id": "com.apple.TextEdit"})(),
+    )
+
+    runner.run_threaded(
+        {
+            "event_type": "AXValueChanged",
+            "bundle_id": "com.apple.Terminal",
+        }
+    )
+
+    assert runner._queue.empty()

--- a/tests/test_capture_metadata.py
+++ b/tests/test_capture_metadata.py
@@ -1,0 +1,330 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from openchronicle.capture import scheduler
+from openchronicle.config import CaptureConfig
+
+
+@dataclass
+class _Result:
+    raw_json: dict
+    metadata: dict
+
+
+class _Provider:
+    available = True
+
+    def __init__(self, raw_json: dict | list[dict]) -> None:
+        self.snapshots = raw_json if isinstance(raw_json, list) else [raw_json]
+        self.calls = 0
+
+    def capture_frontmost(self, *, focused_window_only: bool) -> _Result:
+        assert focused_window_only is True
+        index = min(self.calls, len(self.snapshots) - 1)
+        self.calls += 1
+        return _Result(self.snapshots[index], {})
+
+
+def test_build_capture_prefers_snapshot_title(monkeypatch, ac_root) -> None:
+    monkeypatch.setattr(scheduler.screenshot, "grab", lambda **_: None)
+    monkeypatch.setattr(
+        scheduler.window_meta,
+        "active_window",
+        lambda: (_ for _ in ()).throw(AssertionError("fallback should not run")),
+    )
+    provider = _Provider(
+        {
+            "apps": [
+                {
+                    "name": "TextEdit",
+                    "bundle_id": "com.apple.TextEdit",
+                    "is_frontmost": True,
+                    "focused_element": {"role": "AXTextArea", "value": "body"},
+                    "windows": [
+                        {
+                            "title": "  Snapshot\nTitle  ",
+                            "focused": True,
+                            "elements": [],
+                        }
+                    ],
+                }
+            ]
+        }
+    )
+
+    out = scheduler._build_capture(
+        CaptureConfig(include_screenshot=False),
+        provider,
+        {
+            "event_type": "AXFocusedWindowChanged",
+            "bundle_id": "com.apple.TextEdit",
+            "window_title": "Stale title",
+        },
+    )
+
+    assert out is not None
+    assert out["window_meta"]["title"] == "Snapshot Title"
+    assert out["window_meta"]["title_source"] == "ax_snapshot"
+
+
+def test_build_capture_uses_matching_trigger_title(monkeypatch, ac_root) -> None:
+    monkeypatch.setattr(scheduler, "_AX_RETRY_DELAYS", ())
+    monkeypatch.setattr(scheduler.screenshot, "grab", lambda **_: None)
+    monkeypatch.setattr(
+        scheduler.window_meta,
+        "active_window",
+        lambda: (_ for _ in ()).throw(AssertionError("fallback should not run")),
+    )
+    provider = _Provider(
+        {
+            "apps": [
+                {
+                    "name": "TextEdit",
+                    "bundle_id": "com.apple.TextEdit",
+                    "is_frontmost": True,
+                    "windows": [{"title": "", "focused": True, "elements": []}],
+                }
+            ]
+        }
+    )
+
+    out = scheduler._build_capture(
+        CaptureConfig(include_screenshot=False),
+        provider,
+        {
+            "event_type": "AXFocusedWindowChanged",
+            "bundle_id": "com.apple.TextEdit",
+            "window_title": "Event title",
+        },
+    )
+
+    assert out is not None
+    assert out["window_meta"]["title"] == "Event title"
+    assert out["window_meta"]["title_source"] == "trigger"
+
+
+def test_build_capture_rejects_cross_app_trigger_title(monkeypatch, ac_root) -> None:
+    monkeypatch.setattr(scheduler, "_AX_RETRY_DELAYS", ())
+    monkeypatch.setattr(scheduler.screenshot, "grab", lambda **_: None)
+    monkeypatch.setattr(
+        scheduler.window_meta,
+        "active_window",
+        lambda: scheduler.window_meta.WindowMeta(
+            app_name="TextEdit",
+            title="Current title",
+            bundle_id="com.apple.TextEdit",
+        ),
+    )
+    provider = _Provider(
+        {
+            "apps": [
+                {
+                    "name": "TextEdit",
+                    "bundle_id": "com.apple.TextEdit",
+                    "is_frontmost": True,
+                    "windows": [{"title": "", "focused": True, "elements": []}],
+                }
+            ]
+        }
+    )
+
+    out = scheduler._build_capture(
+        CaptureConfig(include_screenshot=False),
+        provider,
+        {
+            "event_type": "AXFocusedWindowChanged",
+            "bundle_id": "com.google.Chrome",
+            "window_title": "Stale Chrome title",
+        },
+    )
+
+    assert out is not None
+    assert out["window_meta"]["title"] == "Current title"
+    assert out["window_meta"]["title_source"] == "system_events"
+
+
+def test_build_capture_retries_incomplete_textedit_snapshot(monkeypatch, ac_root) -> None:
+    monkeypatch.setattr(scheduler, "_AX_RETRY_DELAYS", (0, 0))
+    monkeypatch.setattr(scheduler.time, "sleep", lambda _: None)
+    monkeypatch.setattr(scheduler.screenshot, "grab", lambda **_: None)
+    incomplete = {
+        "apps": [
+            {
+                "name": "TextEdit",
+                "bundle_id": "com.apple.TextEdit",
+                "is_frontmost": True,
+                "windows": [
+                    {
+                        "title": "Untitled",
+                        "focused": True,
+                        "elements": [{"role": "AXScrollArea"}],
+                    }
+                ],
+            }
+        ]
+    }
+    ready = {
+        "apps": [
+            {
+                "name": "TextEdit",
+                "bundle_id": "com.apple.TextEdit",
+                "is_frontmost": True,
+                "focused_element": {
+                    "role": "AXTextArea",
+                    "identifier": "First Text View",
+                    "value": "OC_TEXTEDIT_BODY_001",
+                },
+                "windows": [
+                    {
+                        "title": "Untitled",
+                        "focused": True,
+                        "elements": [
+                            {
+                                "role": "AXScrollArea",
+                                "children": [
+                                    {
+                                        "role": "AXTextArea",
+                                        "value": "OC_TEXTEDIT_BODY_001",
+                                    }
+                                ],
+                            }
+                        ],
+                    }
+                ],
+            }
+        ]
+    }
+    provider = _Provider([incomplete, ready])
+
+    out = scheduler._build_capture(
+        CaptureConfig(include_screenshot=False),
+        provider,
+        {
+            "event_type": "AXApplicationActivated",
+            "bundle_id": "com.apple.TextEdit",
+            "window_title": "Untitled",
+        },
+    )
+
+    assert out is not None
+    assert provider.calls == 2
+    assert out["focused_element"]["role"] == "AXTextArea"
+    assert "OC_TEXTEDIT_BODY_001" in out["visible_text"]
+    assert out["ax_metadata"]["retry_count"] == 1
+    assert out["ax_metadata"]["app_consistent"] is True
+
+
+def test_build_capture_discards_retry_after_app_switch(monkeypatch, ac_root) -> None:
+    monkeypatch.setattr(scheduler, "_AX_RETRY_DELAYS", (0, 0))
+    monkeypatch.setattr(scheduler.time, "sleep", lambda _: None)
+    monkeypatch.setattr(scheduler.screenshot, "grab", lambda **_: None)
+    monkeypatch.setattr(
+        scheduler.window_meta,
+        "active_window",
+        lambda: scheduler.window_meta.WindowMeta(
+            app_name="TextEdit",
+            title="Untitled",
+            bundle_id="com.apple.TextEdit",
+        ),
+    )
+    textedit = {
+        "apps": [
+            {
+                "name": "TextEdit",
+                "bundle_id": "com.apple.TextEdit",
+                "is_frontmost": True,
+                "windows": [{"title": "Untitled", "focused": True, "elements": []}],
+            }
+        ]
+    }
+    chrome = {
+        "apps": [
+            {
+                "name": "Chrome",
+                "bundle_id": "com.google.Chrome",
+                "is_frontmost": True,
+                "focused_element": {"role": "AXTextField", "value": "https://example.com"},
+                "windows": [{"title": "Example", "focused": True, "elements": []}],
+            }
+        ]
+    }
+    provider = _Provider([textedit, chrome])
+
+    out = scheduler._build_capture(
+        CaptureConfig(include_screenshot=False),
+        provider,
+        {
+            "event_type": "AXApplicationActivated",
+            "bundle_id": "com.apple.TextEdit",
+            "window_title": "Untitled",
+        },
+    )
+
+    assert out is not None
+    assert provider.calls == 2
+    assert out["window_meta"]["bundle_id"] == "com.apple.TextEdit"
+    assert out["focused_element"]["role"] == ""
+    assert out["ax_metadata"]["app_consistent"] is False
+
+
+def test_build_capture_does_not_retry_complete_browser_page(monkeypatch, ac_root) -> None:
+    monkeypatch.setattr(scheduler, "_AX_RETRY_DELAYS", (0, 0))
+    monkeypatch.setattr(
+        scheduler.time,
+        "sleep",
+        lambda _: (_ for _ in ()).throw(AssertionError("browser snapshot must not retry")),
+    )
+    monkeypatch.setattr(scheduler.screenshot, "grab", lambda **_: None)
+    provider = _Provider(
+        {
+            "apps": [
+                {
+                    "name": "Chrome",
+                    "bundle_id": "com.google.Chrome",
+                    "is_frontmost": True,
+                    "windows": [
+                        {
+                            "title": "Example Domain",
+                            "focused": True,
+                            "elements": [
+                                {
+                                    "role": "AXToolbar",
+                                    "children": [
+                                        {
+                                            "role": "AXTextField",
+                                            "title": "Address and search bar",
+                                            "value": "https://example.com/?oc_case=A01",
+                                        }
+                                    ],
+                                },
+                                {
+                                    "role": "AXWebArea",
+                                    "children": [
+                                        {"role": "AXStaticText", "value": "Example Domain"}
+                                    ],
+                                },
+                            ],
+                        }
+                    ],
+                }
+            ]
+        }
+    )
+
+    out = scheduler._build_capture(
+        CaptureConfig(include_screenshot=False),
+        provider,
+        {
+            "event_type": "UserMouseClick",
+            "bundle_id": "com.google.Chrome",
+            "window_title": "Example Domain",
+        },
+    )
+
+    assert out is not None
+    assert provider.calls == 1
+    assert out["focused_element"]["role"] == ""
+    assert out["url"] == "https://example.com/?oc_case=A01"
+    assert out["ax_metadata"]["retry_count"] == 0
+    assert out["ax_metadata"]["app_consistent"] is True

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -6,6 +6,10 @@ from openchronicle import config
 def test_defaults_when_no_file(tmp_path: Path) -> None:
     cfg = config.load(tmp_path / "missing.toml")
     assert cfg.capture.interval_minutes == 10
+    assert cfg.capture.enable_electron_accessibility is True
+    assert cfg.capture.electron_accessibility_bundles == [
+        "com.microsoft.VSCode",
+    ]
     assert cfg.session.gap_minutes == 5
     assert cfg.reducer.enabled is True
     default = cfg.model_for("reducer")
@@ -49,3 +53,17 @@ def test_api_key_precedence(tmp_path: Path, monkeypatch) -> None:
     assert config.resolve_api_key(cfg) == "direct"
     cfg2 = config.ModelConfig(api_key="", api_key_env="ENV_KEY")
     assert config.resolve_api_key(cfg2) == "from-env"
+
+
+def test_electron_accessibility_config_override(tmp_path: Path) -> None:
+    path = tmp_path / "config.toml"
+    path.write_text(
+        """
+[capture]
+enable_electron_accessibility = false
+electron_accessibility_bundles = ["com.example.CustomElectron"]
+"""
+    )
+    cfg = config.load(path)
+    assert cfg.capture.enable_electron_accessibility is False
+    assert cfg.capture.electron_accessibility_bundles == ["com.example.CustomElectron"]

--- a/tests/test_event_dispatcher.py
+++ b/tests/test_event_dispatcher.py
@@ -1,6 +1,10 @@
 from __future__ import annotations
 
+import json
+import time
+
 from openchronicle.capture.event_dispatcher import EventDispatcher
+from openchronicle.capture.signal_store import SignalStore
 
 
 def test_dispatcher_preserves_safe_target_metadata_only() -> None:
@@ -46,3 +50,135 @@ def test_dispatcher_preserves_safe_target_metadata_only() -> None:
             },
         }
     ]
+
+
+def test_text_input_preserves_enter_association_id() -> None:
+    captures: list[dict] = []
+    dispatcher = EventDispatcher(
+        captures.append,
+        min_capture_gap_seconds=0,
+        dedup_interval_seconds=0,
+        same_window_dedup_seconds=0,
+    )
+    dispatcher.on_event(
+        {
+            "event_type": "UserTextInput",
+            "signal_id": "enter-association",
+            "bundle_id": "com.apple.TextEdit",
+            "details": {"reason": "enter"},
+        }
+    )
+
+    assert captures[0]["signal_id"] == "enter-association"
+
+
+def test_user_enter_persists_before_capture_and_bypasses_dedup(ac_root) -> None:
+    captures: list[dict] = []
+    store = SignalStore()
+    dispatcher = EventDispatcher(
+        captures.append,
+        signal_store=store,
+        enter_capture_delay_seconds=0,
+        enter_followup_delay_seconds=None,
+        dedup_interval_seconds=60,
+        same_window_dedup_seconds=60,
+    )
+
+    for index in range(5):
+        dispatcher.on_event(
+            {
+                "event_type": "UserEnter",
+                "signal_id": f"sig-{index}",
+                "timestamp": "2026-07-25T12:00:00+08:00",
+                "pid": 42,
+                "app_name": "TextEdit",
+                "bundle_id": "com.apple.TextEdit",
+                "window_title": "private",
+                "key_variant": "return",
+                "modifiers": [],
+                "input_target": {"role": "AXTextArea", "value": "secret"},
+            }
+        )
+
+    deadline = time.monotonic() + 1
+    while len(captures) < 5 and time.monotonic() < deadline:
+        time.sleep(0.01)
+    dispatcher.shutdown()
+
+    assert len(list((ac_root / "signal-buffer").glob("*.json"))) == 5
+    assert len(captures) == 5
+    assert {capture["signal_id"] for capture in captures} == {
+        "sig-0",
+        "sig-1",
+        "sig-2",
+        "sig-3",
+        "sig-4",
+    }
+
+
+def test_duplicate_signal_id_does_not_request_second_capture(ac_root) -> None:
+    captures: list[dict] = []
+    dispatcher = EventDispatcher(
+        captures.append,
+        signal_store=SignalStore(),
+        enter_capture_delay_seconds=0,
+        enter_followup_delay_seconds=None,
+    )
+    event = {
+        "event_type": "UserEnter",
+        "signal_id": "same-id",
+        "timestamp": "2026-07-25T12:00:00+08:00",
+        "bundle_id": "com.apple.TextEdit",
+        "key_variant": "return",
+    }
+
+    dispatcher.on_event(event)
+    dispatcher.on_event(event)
+    deadline = time.monotonic() + 1
+    while len(captures) < 1 and time.monotonic() < deadline:
+        time.sleep(0.01)
+    dispatcher.shutdown()
+
+    assert len(captures) == 1
+
+
+def test_enter_followup_can_upgrade_late_snapshot(ac_root) -> None:
+    store = SignalStore()
+    attempts: list[str] = []
+
+    def capture(trigger: dict) -> None:
+        attempt = trigger["enter_attempt"]
+        attempts.append(attempt)
+        if attempt == "initial":
+            store.update_snapshot(
+                trigger["signal_id"], status="reused", snapshot_ref="before.json"
+            )
+        else:
+            store.update_snapshot(
+                trigger["signal_id"], status="captured", snapshot_ref="after.json"
+            )
+
+    dispatcher = EventDispatcher(
+        capture,
+        signal_store=store,
+        enter_capture_delay_seconds=0,
+        enter_followup_delay_seconds=0.05,
+    )
+    dispatcher.on_event(
+        {
+            "event_type": "UserEnter",
+            "signal_id": "late-update",
+            "timestamp": "2026-07-25T12:00:00+08:00",
+            "bundle_id": "com.google.Chrome",
+            "key_variant": "return",
+        }
+    )
+    deadline = time.monotonic() + 1
+    while len(attempts) < 2 and time.monotonic() < deadline:
+        time.sleep(0.01)
+    dispatcher.shutdown()
+
+    signal = json.loads((ac_root / "signal-buffer" / "late-update.json").read_text())
+    assert attempts == ["initial", "followup"]
+    assert signal["snapshot_status"] == "captured"
+    assert signal["snapshot_ref"] == "after.json"

--- a/tests/test_event_dispatcher.py
+++ b/tests/test_event_dispatcher.py
@@ -52,7 +52,7 @@ def test_dispatcher_preserves_safe_target_metadata_only() -> None:
     ]
 
 
-def test_text_input_preserves_enter_association_id() -> None:
+def test_text_input_preserves_v2_enter_relationship() -> None:
     captures: list[dict] = []
     dispatcher = EventDispatcher(
         captures.append,
@@ -63,22 +63,33 @@ def test_text_input_preserves_enter_association_id() -> None:
     dispatcher.on_event(
         {
             "event_type": "UserTextInput",
-            "signal_id": "enter-association",
+            "event_id": "text-event",
+            "correlation_id": "interaction",
+            "related_signal_id": "enter-association",
             "bundle_id": "com.apple.TextEdit",
             "details": {"reason": "enter"},
         }
     )
 
-    assert captures[0]["signal_id"] == "enter-association"
+    assert captures[0]["event_id"] == "text-event"
+    assert captures[0]["correlation_id"] == "interaction"
+    assert captures[0]["related_signal_id"] == "enter-association"
 
 
 def test_user_enter_persists_before_capture_and_bypasses_dedup(ac_root) -> None:
     captures: list[dict] = []
+
+    def capture(trigger: dict) -> None:
+        captures.append(trigger)
+        trigger["_capture_complete"](
+            {"status": "new", "quality_status": "good", "snapshot_ref": "shared.json"}
+        )
+
     store = SignalStore()
     dispatcher = EventDispatcher(
-        captures.append,
+        capture,
         signal_store=store,
-        enter_capture_delay_seconds=0,
+        enter_capture_delay_seconds=0.05,
         enter_followup_delay_seconds=None,
         dedup_interval_seconds=60,
         same_window_dedup_seconds=60,
@@ -101,19 +112,26 @@ def test_user_enter_persists_before_capture_and_bypasses_dedup(ac_root) -> None:
         )
 
     deadline = time.monotonic() + 1
-    while len(captures) < 5 and time.monotonic() < deadline:
+    while len(captures) < 1 and time.monotonic() < deadline:
         time.sleep(0.01)
     dispatcher.shutdown()
 
     assert len(list((ac_root / "signal-buffer").glob("*.json"))) == 5
-    assert len(captures) == 5
-    assert {capture["signal_id"] for capture in captures} == {
+    assert len(captures) == 1
+    assert set(captures[0]["member_signal_ids"]) == {
         "sig-0",
         "sig-1",
         "sig-2",
         "sig-3",
         "sig-4",
     }
+    for index in range(5):
+        signal = json.loads(
+            (ac_root / "signal-buffer" / f"sig-{index}.json").read_text()
+        )
+        assert signal["post_capture_status"] == "new"
+        assert signal["result_snapshot_ref"] == "shared.json"
+        assert signal["capture_attempts"][0]["association_mode"] == "coalesced"
 
 
 def test_duplicate_signal_id_does_not_request_second_capture(ac_root) -> None:
@@ -150,12 +168,20 @@ def test_enter_followup_can_upgrade_late_snapshot(ac_root) -> None:
         attempt = trigger["enter_attempt"]
         attempts.append(attempt)
         if attempt == "initial":
-            store.update_snapshot(
-                trigger["signal_id"], status="reused", snapshot_ref="before.json"
+            trigger["_capture_complete"](
+                {
+                    "status": "reused",
+                    "quality_status": "good",
+                    "snapshot_ref": "before.json",
+                }
             )
         else:
-            store.update_snapshot(
-                trigger["signal_id"], status="captured", snapshot_ref="after.json"
+            trigger["_capture_complete"](
+                {
+                    "status": "new",
+                    "quality_status": "good",
+                    "snapshot_ref": "after.json",
+                }
             )
 
     dispatcher = EventDispatcher(
@@ -179,6 +205,113 @@ def test_enter_followup_can_upgrade_late_snapshot(ac_root) -> None:
     dispatcher.shutdown()
 
     signal = json.loads((ac_root / "signal-buffer" / "late-update.json").read_text())
-    assert attempts == ["initial", "followup"]
-    assert signal["snapshot_status"] == "captured"
-    assert signal["snapshot_ref"] == "after.json"
+    assert attempts == ["initial", "follow_up"]
+    assert signal["post_capture_status"] == "new"
+    assert signal["result_snapshot_ref"] == "after.json"
+
+
+def test_high_quality_primary_cancels_followup(ac_root) -> None:
+    attempts: list[str] = []
+
+    def capture(trigger: dict) -> None:
+        attempts.append(trigger["enter_attempt"])
+        trigger["_capture_complete"](
+            {"status": "new", "quality_status": "good", "snapshot_ref": "new.json"}
+        )
+
+    dispatcher = EventDispatcher(
+        capture,
+        signal_store=SignalStore(),
+        enter_capture_delay_seconds=0,
+        enter_followup_delay_seconds=0.02,
+    )
+    dispatcher.on_event(
+        {
+            "event_type": "UserEnter",
+            "signal_id": "primary-good",
+            "bundle_id": "com.apple.TextEdit",
+            "key_variant": "return",
+        }
+    )
+    time.sleep(0.08)
+    dispatcher.shutdown()
+
+    assert attempts == ["initial"]
+
+
+def test_shutdown_marks_unstarted_primary_deferred(ac_root) -> None:
+    dispatcher = EventDispatcher(
+        lambda trigger: None,
+        signal_store=SignalStore(),
+        enter_capture_delay_seconds=10,
+        enter_followup_delay_seconds=None,
+    )
+    dispatcher.on_event(
+        {
+            "event_type": "UserEnter",
+            "signal_id": "shutdown-pending",
+            "bundle_id": "com.apple.TextEdit",
+            "key_variant": "return",
+        }
+    )
+    dispatcher.shutdown()
+
+    signal = json.loads(
+        (ac_root / "signal-buffer" / "shutdown-pending.json").read_text()
+    )
+    assert signal["post_capture_status"] == "deferred_shutdown"
+    assert signal["capture_attempts"][-1]["status"] == "cancelled_shutdown"
+
+
+def test_capture_group_allows_only_one_natural_event_attempt(ac_root) -> None:
+    attempts: list[str] = []
+
+    def capture(trigger: dict) -> None:
+        attempt = trigger["enter_attempt"]
+        attempts.append(attempt)
+        if attempt == "follow_up":
+            outcome = {
+                "status": "new",
+                "quality_status": "good",
+                "snapshot_ref": "after.json",
+            }
+        else:
+            outcome = {
+                "status": "reused",
+                "quality_status": "good",
+                "snapshot_ref": "before.json",
+            }
+        trigger["_capture_complete"](outcome)
+
+    dispatcher = EventDispatcher(
+        capture,
+        signal_store=SignalStore(),
+        enter_capture_delay_seconds=0,
+        enter_followup_delay_seconds=0.08,
+        debounce_seconds=10,
+    )
+    dispatcher.on_event(
+        {
+            "event_type": "UserEnter",
+            "signal_id": "natural-once",
+            "pid": 42,
+            "bundle_id": "com.apple.TextEdit",
+            "key_variant": "return",
+        }
+    )
+    deadline = time.monotonic() + 1
+    while attempts != ["initial"] and time.monotonic() < deadline:
+        time.sleep(0.005)
+    natural = {
+        "event_type": "AXValueChanged",
+        "pid": 42,
+        "bundle_id": "com.apple.TextEdit",
+    }
+    dispatcher.on_event(natural)
+    dispatcher.on_event(natural)
+    deadline = time.monotonic() + 1
+    while len(attempts) < 3 and time.monotonic() < deadline:
+        time.sleep(0.005)
+    dispatcher.shutdown()
+
+    assert attempts == ["initial", "natural_event", "follow_up"]

--- a/tests/test_event_dispatcher.py
+++ b/tests/test_event_dispatcher.py
@@ -1,0 +1,48 @@
+from __future__ import annotations
+
+from openchronicle.capture.event_dispatcher import EventDispatcher
+
+
+def test_dispatcher_preserves_safe_target_metadata_only() -> None:
+    captures: list[dict] = []
+    dispatcher = EventDispatcher(
+        captures.append,
+        min_capture_gap_seconds=0,
+        dedup_interval_seconds=0,
+        same_window_dedup_seconds=0,
+    )
+    dispatcher.on_event(
+        {
+            "event_type": "UserTextInput",
+            "bundle_id": "com.example.App",
+            "window_title": "Document",
+            "details": {
+                "reason": "debounce",
+                "x": 12,
+                "y": 34,
+                "element": {
+                    "role": "AXTextArea",
+                    "subrole": "AXStandardTextArea",
+                    "identifier": "editor",
+                    "title": "private title",
+                    "value": "secret contents",
+                },
+            },
+        }
+    )
+
+    assert captures == [
+        {
+            "event_type": "UserTextInput",
+            "bundle_id": "com.example.App",
+            "window_title": "Document",
+            "details": {
+                "reason": "debounce",
+                "element": {
+                    "role": "AXTextArea",
+                    "subrole": "AXStandardTextArea",
+                    "identifier": "editor",
+                },
+            },
+        }
+    ]

--- a/tests/test_s1_parser.py
+++ b/tests/test_s1_parser.py
@@ -22,6 +22,12 @@ def test_enrich_picks_frontmost_app() -> None:
                 "name": "Cursor",
                 "bundle_id": "com.todesktop.230313mzl4w4u92",
                 "is_frontmost": True,
+                "focused_element": {
+                    "role": "AXTextArea",
+                    "title": "editor",
+                    "value": "def enrich(capture):\n    ...",
+                    "focused": True,
+                },
                 "windows": [
                     {
                         "title": "s1_parser.py",
@@ -54,6 +60,12 @@ def test_enrich_extracts_browser_url() -> None:
                 "name": "Chrome",
                 "bundle_id": "com.google.Chrome",
                 "is_frontmost": True,
+                "focused_element": {
+                    "role": "AXTextField",
+                    "title": "Address and search bar",
+                    "value": "https://www.anthropic.com/news",
+                    "focused": True,
+                },
                 "windows": [
                     {
                         "title": "Anthropic",
@@ -89,6 +101,7 @@ def test_enrich_prefixes_bare_url() -> None:
                         "elements": [
                             {
                                 "role": "AXTextField",
+                                "title": "Address and search bar",
                                 "value": "anthropic.com",
                             }
                         ],
@@ -99,6 +112,176 @@ def test_enrich_prefixes_bare_url() -> None:
     }
     s1_parser.enrich(capture)
     assert capture["url"] == "https://anthropic.com"
+
+
+def test_enrich_recurses_for_explicitly_focused_fallback() -> None:
+    capture = {
+        "ax_tree": _ax_tree(
+            {
+                "name": "Chrome",
+                "bundle_id": "com.google.Chrome",
+                "is_frontmost": True,
+                "windows": [
+                    {
+                        "title": "Nested",
+                        "focused": True,
+                        "elements": [
+                            {
+                                "role": "AXGroup",
+                                "children": [
+                                    {
+                                        "role": "AXTextField",
+                                        "value": "query",
+                                        "focused": True,
+                                    }
+                                ],
+                            }
+                        ],
+                    }
+                ],
+            }
+        )
+    }
+    s1_parser.enrich(capture)
+    assert capture["focused_element"]["role"] == "AXTextField"
+    assert capture["focused_element"]["value"] == "query"
+
+
+def test_enrich_does_not_guess_first_text_node_as_focus() -> None:
+    capture = {
+        "ax_tree": _ax_tree(
+            {
+                "name": "TextEdit",
+                "bundle_id": "com.apple.TextEdit",
+                "is_frontmost": True,
+                "windows": [
+                    {
+                        "title": "Document",
+                        "focused": True,
+                        "elements": [
+                            {"role": "AXStaticText", "value": "heading"},
+                            {"role": "AXTextArea", "value": "body"},
+                        ],
+                    }
+                ],
+            }
+        )
+    }
+    s1_parser.enrich(capture)
+    assert capture["focused_element"]["role"] == ""
+
+
+def test_enrich_extracts_nested_combobox_address_bar() -> None:
+    capture = {
+        "ax_tree": _ax_tree(
+            {
+                "name": "Chrome",
+                "bundle_id": "com.google.Chrome",
+                "is_frontmost": True,
+                "windows": [
+                    {
+                        "title": "Example",
+                        "focused": True,
+                        "elements": [
+                            {
+                                "role": "AXToolbar",
+                                "children": [
+                                    {
+                                        "role": "AXGroup",
+                                        "children": [
+                                            {
+                                                "role": "AXComboBox",
+                                                "identifier": "location_bar",
+                                                "value": "HTTPS://Example.COM/Path",
+                                            }
+                                        ],
+                                    }
+                                ],
+                            }
+                        ],
+                    }
+                ],
+            }
+        )
+    }
+    s1_parser.enrich(capture)
+    assert capture["url"] == "https://example.com/Path"
+    assert capture["url_source"] == "ax_address_bar"
+
+
+def test_enrich_rejects_ambiguous_page_url_fields() -> None:
+    capture = {
+        "ax_tree": _ax_tree(
+            {
+                "name": "Chrome",
+                "bundle_id": "com.google.Chrome",
+                "is_frontmost": True,
+                "windows": [
+                    {
+                        "title": "Form",
+                        "focused": True,
+                        "elements": [
+                            {
+                                "role": "AXWebArea",
+                                "children": [
+                                    {"role": "AXTextField", "value": "https://one.example"},
+                                    {"role": "AXTextField", "value": "https://two.example"},
+                                ],
+                            }
+                        ],
+                    }
+                ],
+            }
+        )
+    }
+    s1_parser.enrich(capture)
+    assert capture["url"] is None
+    assert capture["url_source"] == "unavailable"
+
+
+def test_normalize_url_handles_supported_special_cases() -> None:
+    assert s1_parser._normalize_url(" localhost:8000/path ") == "https://localhost:8000/path"
+    assert s1_parser._normalize_url("http://127.0.0.1:8742/MCP") == ("http://127.0.0.1:8742/MCP")
+    assert s1_parser._normalize_url("http://[::1]:8080/Path") == ("http://[::1]:8080/Path")
+    assert s1_parser._normalize_url("chrome://settings/privacy") == ("chrome://settings/privacy")
+    assert s1_parser._normalize_url("file:///Users/example/Test.txt") == (
+        "file:///Users/example/Test.txt"
+    )
+    assert s1_parser._normalize_url("https://user:secret@Example.COM/Path") == (
+        "https://example.com/Path"
+    )
+
+
+def test_enrich_does_not_treat_page_search_box_as_address_bar() -> None:
+    capture = {
+        "ax_tree": _ax_tree(
+            {
+                "name": "Chrome",
+                "bundle_id": "com.google.Chrome",
+                "is_frontmost": True,
+                "windows": [
+                    {
+                        "title": "Search form",
+                        "focused": True,
+                        "elements": [
+                            {
+                                "role": "AXWebArea",
+                                "children": [
+                                    {
+                                        "role": "AXTextField",
+                                        "title": "Search bar",
+                                        "value": "https://not-the-page.example",
+                                    }
+                                ],
+                            }
+                        ],
+                    }
+                ],
+            }
+        )
+    }
+    s1_parser.enrich(capture)
+    assert capture["url"] is None
 
 
 def test_enrich_non_browser_has_no_url() -> None:
@@ -163,9 +346,7 @@ def test_enrich_no_focused_window_returns_empty_element() -> None:
                     {
                         "title": "unfocused",
                         "focused": False,
-                        "elements": [
-                            {"role": "AXTextField", "value": "something"}
-                        ],
+                        "elements": [{"role": "AXTextField", "value": "something"}],
                     }
                 ],
             }

--- a/tests/test_signal_store.py
+++ b/tests/test_signal_store.py
@@ -1,0 +1,98 @@
+from __future__ import annotations
+
+import json
+
+from openchronicle.capture.signal_store import SignalStore, sanitize_user_enter
+
+
+def _enter(signal_id: str = "sig-1", **overrides: object) -> dict:
+    event = {
+        "event_type": "UserEnter",
+        "signal_id": signal_id,
+        "timestamp": "2026-07-25T12:00:00+08:00",
+        "pid": 42,
+        "app_name": "Terminal",
+        "bundle_id": "com.apple.Terminal",
+        "window_title": "secret-token-in-title",
+        "key_variant": "return",
+        "modifiers": ["shift", "command", "invalid"],
+        "input_target": {
+            "role": "AXTextField",
+            "subrole": "AXStandardTextField",
+            "identifier": "input",
+            "title": "private title",
+            "value": "sk-secret-value",
+        },
+        "input_target_status": "available",
+        "semantic_intent": "submit",
+    }
+    event.update(overrides)
+    return event
+
+
+def test_sanitize_user_enter_is_strict_allowlist() -> None:
+    signal = sanitize_user_enter(_enter())
+
+    assert signal is not None
+    assert signal["window_title"] == ""
+    assert signal["semantic_intent"] == "unknown"
+    assert signal["modifiers"] == ["shift", "command"]
+    assert signal["input_target"] == {
+        "role": "AXTextField",
+        "subrole": "AXStandardTextField",
+        "identifier": "input",
+    }
+    serialized = json.dumps(signal)
+    assert "secret-token" not in serialized
+    assert "sk-secret" not in serialized
+    assert "private title" not in serialized
+    assert "submit" not in serialized
+
+
+def test_secure_target_is_removed() -> None:
+    signal = sanitize_user_enter(_enter(input_target_status="secure_input"))
+
+    assert signal is not None
+    assert signal["input_target"] is None
+    assert signal["input_target_status"] == "secure_input"
+
+
+def test_signal_store_is_idempotent(ac_root) -> None:
+    store = SignalStore()
+
+    first = store.create_user_enter(_enter())
+    second = store.create_user_enter(_enter())
+
+    assert first.created is True
+    assert second.created is False
+    files = list((ac_root / "signal-buffer").glob("*.json"))
+    assert len(files) == 1
+
+
+def test_excluded_bundle_is_not_persisted(ac_root) -> None:
+    store = SignalStore(excluded_bundle_ids={"com.apple.Terminal"})
+
+    result = store.create_user_enter(_enter())
+
+    assert result.created is False
+    assert list((ac_root / "signal-buffer").glob("*.json")) == []
+
+
+def test_unsafe_signal_id_is_rejected(ac_root) -> None:
+    store = SignalStore()
+
+    result = store.create_user_enter(_enter("../outside"))
+
+    assert result.created is False
+    assert list((ac_root / "signal-buffer").glob("*.json")) == []
+
+
+def test_snapshot_update_preserves_signal(ac_root) -> None:
+    store = SignalStore()
+    store.create_user_enter(_enter())
+
+    store.update_snapshot("sig-1", status="reused", snapshot_ref="snapshot.json")
+
+    signal = json.loads((ac_root / "signal-buffer" / "sig-1.json").read_text())
+    assert signal["snapshot_status"] == "reused"
+    assert signal["snapshot_ref"] == "snapshot.json"

--- a/tests/test_signal_store.py
+++ b/tests/test_signal_store.py
@@ -2,7 +2,11 @@ from __future__ import annotations
 
 import json
 
-from openchronicle.capture.signal_store import SignalStore, sanitize_user_enter
+from openchronicle.capture.signal_store import (
+    SignalStore,
+    sanitize_user_enter,
+    sanitize_user_text_input,
+)
 
 
 def _enter(signal_id: str = "sig-1", **overrides: object) -> dict:
@@ -34,7 +38,9 @@ def test_sanitize_user_enter_is_strict_allowlist() -> None:
     signal = sanitize_user_enter(_enter())
 
     assert signal is not None
-    assert signal["window_title"] == ""
+    assert "window_title" not in signal
+    assert signal["signal_schema_version"] == 2
+    assert signal["revision"] == 1
     assert signal["semantic_intent"] == "unknown"
     assert signal["modifiers"] == ["shift", "command"]
     assert signal["input_target"] == {
@@ -94,5 +100,167 @@ def test_snapshot_update_preserves_signal(ac_root) -> None:
     store.update_snapshot("sig-1", status="reused", snapshot_ref="snapshot.json")
 
     signal = json.loads((ac_root / "signal-buffer" / "sig-1.json").read_text())
-    assert signal["snapshot_status"] == "reused"
-    assert signal["snapshot_ref"] == "snapshot.json"
+    assert signal["post_capture_status"] == "reused"
+    assert signal["result_snapshot_ref"] == "snapshot.json"
+
+
+def test_identifier_with_control_characters_is_removed() -> None:
+    signal = sanitize_user_enter(
+        _enter(input_target={"role": "AXTextField", "identifier": "secret\nvalue"})
+    )
+
+    assert signal is not None
+    assert signal["input_target"] == {"role": "AXTextField"}
+
+
+def test_success_result_cannot_be_downgraded_and_revision_increments(ac_root) -> None:
+    store = SignalStore()
+    store.create_user_enter(_enter())
+
+    first = store.update_linkage(
+        "sig-1",
+        post_capture_status="new",
+        quality_status="good",
+        result_snapshot_ref="new.json",
+    )
+    second = store.update_linkage(
+        "sig-1",
+        post_capture_status="deferred_queue_full",
+        quality_status="failed",
+    )
+    signal = json.loads((ac_root / "signal-buffer" / "sig-1.json").read_text())
+
+    assert first.updated is True
+    assert second.updated is False
+    assert signal["revision"] == 2
+    assert signal["post_capture_status"] == "new"
+    assert signal["result_snapshot_ref"] == "new.json"
+
+
+def test_attempt_updates_are_idempotent(ac_root) -> None:
+    store = SignalStore()
+    store.create_user_enter(_enter())
+    attempt = {
+        "attempt_id": "att-1",
+        "capture_request_id": "cap-1",
+        "phase": "primary",
+        "association_mode": "direct",
+        "status": "running",
+    }
+
+    store.update_linkage("sig-1", attempt=attempt, post_capture_status="running")
+    store.update_linkage("sig-1", attempt=attempt, post_capture_status="running")
+    signal = json.loads((ac_root / "signal-buffer" / "sig-1.json").read_text())
+
+    assert len(signal["capture_attempts"]) == 1
+
+
+def test_attempt_completion_preserves_requested_timestamps(ac_root) -> None:
+    store = SignalStore()
+    store.create_user_enter(_enter())
+    store.update_linkage(
+        "sig-1",
+        attempt={
+            "attempt_id": "att-timing",
+            "capture_request_id": "cap-1",
+            "phase": "primary",
+            "association_mode": "direct",
+            "requested_at": "2026-07-25T12:00:00+08:00",
+            "due_at": "2026-07-25T12:00:00.200+08:00",
+            "started_at": "2026-07-25T12:00:00.201+08:00",
+            "status": "running",
+        },
+        post_capture_status="running",
+    )
+    store.update_linkage(
+        "sig-1",
+        attempt={
+            "attempt_id": "att-timing",
+            "capture_request_id": "cap-1",
+            "phase": "primary",
+            "association_mode": "direct",
+            "completed_at": "2026-07-25T12:00:00.500+08:00",
+            "status": "new",
+        },
+        post_capture_status="new",
+        quality_status="good",
+        result_snapshot_ref="new.json",
+    )
+
+    signal = json.loads((ac_root / "signal-buffer" / "sig-1.json").read_text())
+    attempt = signal["capture_attempts"][0]
+    assert attempt["requested_at"] == "2026-07-25T12:00:00+08:00"
+    assert attempt["due_at"] == "2026-07-25T12:00:00.200+08:00"
+    assert attempt["started_at"] == "2026-07-25T12:00:00.201+08:00"
+    assert attempt["completed_at"] == "2026-07-25T12:00:00.500+08:00"
+
+
+def test_known_v1_schema_migrates_once(ac_root) -> None:
+    signal_dir = ac_root / "signal-buffer"
+    signal_dir.mkdir(parents=True, exist_ok=True)
+    path = signal_dir / "legacy-1.json"
+    path.write_text(
+        json.dumps(
+            {
+                "schema_version": 1,
+                "signal_id": "legacy-1",
+                "event_type": "UserEnter",
+                "timestamp": "2026-07-25T12:00:00+08:00",
+                "pid": 42,
+                "app_name": "TextEdit",
+                "bundle_id": "com.apple.TextEdit",
+                "key_variant": "return",
+                "modifiers": [],
+                "input_target": {"role": "AXTextArea"},
+                "input_target_status": "available",
+                "snapshot_status": "reused",
+                "snapshot_ref": "old.json",
+            }
+        )
+    )
+    store = SignalStore()
+
+    store.recover_incomplete()
+    first = path.read_text()
+    store.recover_incomplete()
+
+    signal = json.loads(path.read_text())
+    assert path.read_text() == first
+    assert signal["signal_schema_version"] == 2
+    assert signal["migrated_from_schema_version"] == 1
+    assert signal["post_capture_status"] == "reused"
+    assert signal["result_snapshot_ref"] == "old.json"
+
+
+def test_user_text_input_event_is_relationship_only_and_idempotent(ac_root) -> None:
+    raw = {
+        "event_type": "UserTextInput",
+        "event_id": "evt-1",
+        "correlation_id": "corr-1",
+        "related_signal_id": "sig-1",
+        "timestamp": "2026-07-27T12:00:00+08:00",
+        "pid": 42,
+        "app_name": "TextEdit",
+        "bundle_id": "com.apple.TextEdit",
+        "window_title": "private",
+        "details": {
+            "reason": "enter",
+            "element": {
+                "role": "AXTextArea",
+                "identifier": "First Text View",
+                "title": "private",
+                "value": "V2_PRIVATE_TEXT",
+            },
+        },
+    }
+    event = sanitize_user_text_input(raw)
+    assert event is not None
+    serialized = json.dumps(event)
+    assert "V2_PRIVATE_TEXT" not in serialized
+    assert "private" not in serialized
+    assert event["related_signal_id"] == "sig-1"
+
+    store = SignalStore()
+    assert store.create_user_text_input(raw).created is True
+    assert store.create_user_text_input(raw).created is False
+    assert len(list((ac_root / "event-buffer").glob("*.json"))) == 1


### PR DESCRIPTION
## 背景

本 PR 汇总了 macOS AX 捕获可靠性修复、第一轮 UserEnter Signal，以及根据第二轮 review 完成的 V2 生命周期设计。Enter 仅作为被动 side-channel capture signal，不拦截按键，也不推断 submit 语义。

## 主要修改

- 使用真实 focused AX element，并改进 TextEdit / Electron / URL 等捕获可靠性
- 持久化物理 `UserEnter` Signal，并关联 `UserTextInput`
- 每个对象使用独立主键，通过 `correlation_id` 和 `related_signal_id` 建立关系
- 引入条件式 primary / natural-event / follow-up Capture
- 使用 Capture Group 合并短时间内多个 Enter，同时保留每条独立 Signal
- 区分按键前 Context、按键后 Result、Capture Request 和 Attempt ledger
- 增加 revision、幂等合并、状态机、shutdown/recovery 和 daemon singleton lock
- 将 excluded-app 与 Secure Input 隐私阻止前移，并增加 Capture 前后的 defense-in-depth 检查
- 新增最小化的 `event-buffer`，不保存输入文本或 focused value

## 验证结果

- Python full suite: **139 passed**
- Changed-file Ruff: passed
- `git diff --check`: passed
- Swift watcher/helper build: passed
- Swift Enter self-tests: passed
- 真实 macOS 手测：TextEdit、Terminal、Chrome、Electron、中文输入法、快速 5 次、连续 20 次、excluded app、Secure Input、singleton、shutdown/restart 均完成
- 高频 20 次 Enter：20 个唯一 Signal、0 丢失、0 pending、0 queue full
- excluded app：UserTextInput / UserEnter / Snapshot / 测试文本落盘均为 0
- Secure Input：密码框 Enter 被抑制，测试秘密落盘为 0

## Review 资料

- [飞书：OpenChronicle UserEnter Signal V2 更新后实现报告](https://fcnv24tcduwp.feishu.cn/wiki/XoCrweVScix0YTkdyZxcq919n0d)
- Repo 内实现报告：`docs/user-enter-signal-v2-implementation-report.md`
- Repo 内手动测试报告：`docs/user-enter-signal-v2-manual-test-report.md`

## 已知测试边界

- 当前测试机器没有独立数字小键盘，未做真实 keypad Enter 手测；映射逻辑由 Swift self-test 覆盖
- 强制崩溃后的 incomplete recovery 主要由自动化测试覆盖；真实测试覆盖 SIGTERM 优雅关闭、队列收敛、锁释放和同 root 重启
